### PR TITLE
Update generic multimodal dataset

### DIFF
--- a/terratorch/datamodules/generic_multimodal_data_module.py
+++ b/terratorch/datamodules/generic_multimodal_data_module.py
@@ -3,7 +3,7 @@
 """
 This module contains generic data modules for instantiation at runtime.
 """
-import os
+
 import logging
 import warnings
 from collections.abc import Callable, Iterable
@@ -207,6 +207,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         num_workers: int = 0,
         pin_memory: bool = False,
         data_with_sample_dim: bool = False,
+        allow_missing_modalities: bool = False,
         sample_num_modalities: int | None = None,
         sample_replace: bool = False,
         channel_position: int = -3,
@@ -312,6 +313,8 @@ class GenericMultiModalDataModule(NonGeoDataModule):
                 returning them. Defaults to False.
             data_with_sample_dim (bool): Use a specific collate function to concatenate samples along a existing sample
                 dimension instead of stacking the samples. Defaults to False.
+            allow_missing_modalities (bool): Experimental feature! Allow missing modalities during data loading.
+                Defaults to False.
             sample_num_modalities (int, optional): Load only a subset of modalities per batch. Defaults to None.
             sample_replace (bool): If sample_num_modalities is set, sample modalities with replacement.
                 Defaults to False.
@@ -361,14 +364,17 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         self.test_label_data_root = test_label_data_root
         self.predict_root = predict_data_root
 
-        assert not train_data_root or all(m in train_data_root for m in modalities), \
-            f"predict_data_root is missing paths to some modalities {modalities}: {train_data_root}"
-        assert not val_data_root or all(m in val_data_root for m in modalities), \
-            f"predict_data_root is missing paths to some modalities {modalities}: {val_data_root}"
-        assert not test_data_root or all(m in test_data_root for m in modalities), \
-            f"predict_data_root is missing paths to some modalities {modalities}: {test_data_root}"
-        assert not predict_data_root or all(m in predict_data_root for m in modalities), \
-            f"predict_data_root is missing paths to some modalities {modalities}: {predict_data_root}"
+        # Check paths and modalities
+        for name, data_root in [("train", train_data_root), ("val", val_data_root), ("test", test_data_root),
+                                ("predict", predict_data_root)]:
+            if data_root is None:
+                pass
+            elif allow_missing_modalities:
+                if not set(data_root.keys()) <= set(modalities):
+                    raise ValueError(f"Modalities {modalities} do not match {name}_data_root: {data_root}")
+            else:
+                if not set(data_root.keys()) == set(modalities):
+                    raise ValueError(f"Paths in {name}_data_root do not match modalities {modalities}: {data_root}")
 
         self.train_split = train_split
         self.val_split = val_split
@@ -379,8 +385,13 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         self.no_label_replace = no_label_replace
         self.drop_last = drop_last
         self.pin_memory = pin_memory
+        self.allow_missing_modalities = allow_missing_modalities
         self.sample_num_modalities = sample_num_modalities
-        self.sample_replace = sample_replace        
+        self.sample_replace = sample_replace
+        if allow_missing_modalities and batch_size > 1:
+            warnings.warn("allow_missing_modalities is set to True. This is an experimental feature."
+                          "Stacking is currently not supported, setting batch_size to 1.")
+            self.batch_size = 1
 
         self.dataset_bands = dataset_bands
         self.output_bands = output_bands
@@ -393,8 +404,6 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         self.reduce_zero_label = reduce_zero_label
         self.channel_position = channel_position
         self.concat_bands = concat_bands
-        if not concat_bands and check_stackability:
-            logger.debug(f"Cannot check stackability if bands are not concatenated.")
         self.check_stackability = check_stackability
 
         if isinstance(train_transform, dict):
@@ -458,6 +467,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
                 label_grep=self.label_grep,
                 label_data_root=self.train_label_data_root,
                 split=self.train_split,
+                allow_missing_modalities=self.allow_missing_modalities,
                 allow_substring_file_names=self.allow_substring_file_names,
                 dataset_bands=self.dataset_bands,
                 output_bands=self.output_bands,
@@ -483,6 +493,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
                 label_grep=self.label_grep,
                 label_data_root=self.val_label_data_root,
                 split=self.val_split,
+                allow_missing_modalities=self.allow_missing_modalities,
                 allow_substring_file_names=self.allow_substring_file_names,
                 dataset_bands=self.dataset_bands,
                 output_bands=self.output_bands,
@@ -508,6 +519,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
                 label_grep=self.label_grep,
                 label_data_root=self.test_label_data_root,
                 split=self.test_split,
+                allow_missing_modalities=self.allow_missing_modalities,
                 allow_substring_file_names=self.allow_substring_file_names,
                 dataset_bands=self.dataset_bands,
                 output_bands=self.output_bands,
@@ -532,6 +544,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
                 num_classes=self.num_classes,
                 image_grep=self.image_grep,
                 label_grep=self.label_grep,
+                allow_missing_modalities=self.allow_missing_modalities,
                 allow_substring_file_names=self.allow_substring_file_names,
                 dataset_bands=self.predict_dataset_bands,
                 output_bands=self.predict_output_bands,
@@ -566,7 +579,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         dataset = self._valid_attribute(f"{split}_dataset", "dataset")
         batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
 
-        if self.check_stackability:
+        if self.check_stackability and batch_size > 1:
             logger.info(f'Checking dataset stackability for {split} split')
             if self.concat_bands:
                 batch_size = check_dataset_stackability(dataset, batch_size)

--- a/terratorch/datasets/generic_multimodal_dataset.py
+++ b/terratorch/datasets/generic_multimodal_dataset.py
@@ -118,7 +118,6 @@ class GenericMultimodalDataset(NonGeoDataset, ABC):
             rgb_modality (str, optional): Modality used for RGB plots. Defaults to first modality in data_root.keys().
             rgb_indices (list[str], optional): Indices of RGB channels. Defaults to [0, 1, 2].
             allow_missing_modalities (bool, optional): Allow missing modalities during data loading. Defaults to False.
-                TODO: Currently not implemented on a data module level!
             allow_substring_file_names (bool, optional): Allow substrings during sample identification by adding
                 image or label grep to the sample prefixes. If False, treats sample prefixes as full file names.
                 If True and no split file is provided, considers the file stem as prefix, otherwise the full file name.
@@ -203,8 +202,6 @@ class GenericMultimodalDataset(NonGeoDataset, ABC):
             image_files = {}
             for m, m_paths in data_root.items():
                 image_files[m] = sorted(glob.glob(os.path.join(m_paths, image_grep[m])))
-            if label_data_root is not None:
-                image_files["mask"] = sorted(glob.glob(os.path.join(label_data_root, label_grep)))
 
             def get_file_id(file_name, mod):
                 glob_as_regex = '^' + ''.join('(.*?)' if ch == '*' else re.escape(ch)
@@ -541,7 +538,6 @@ class GenericMultimodalSegmentationDataset(GenericMultimodalDataset):
             rgb_modality (str, optional): Modality used for RGB plots. Defaults to first modality in data_root.keys().
             rgb_indices (list[str], optional): Indices of RGB channels. Defaults to [0, 1, 2].
             allow_missing_modalities (bool, optional): Allow missing modalities during data loading. Defaults to False.
-                TODO: Currently not implemented on a data module level!
             allow_substring_file_names (bool, optional): Allow substrings during sample identification by adding
                 image or label grep to the sample prefixes. If False, treats sample prefixes as full file names.
                 If True and no split file is provided, considers the file stem as prefix, otherwise the full file name.
@@ -748,7 +744,6 @@ class GenericMultimodalPixelwiseRegressionDataset(GenericMultimodalDataset):
             rgb_modality (str, optional): Modality used for RGB plots. Defaults to first modality in data_root.keys().
             rgb_indices (list[str], optional): Indices of RGB channels. Defaults to [0, 1, 2].
             allow_missing_modalities (bool, optional): Allow missing modalities during data loading. Defaults to False.
-                TODO: Currently not implemented on a data module level!
             allow_substring_file_names (bool, optional): Allow substrings during sample identification by adding
                 image or label grep to the sample prefixes. If False, treats sample prefixes as full file names.
                 If True and no split file is provided, considers the file stem as prefix, otherwise the full file name.
@@ -942,7 +937,6 @@ class GenericMultimodalScalarDataset(GenericMultimodalDataset):
             rgb_modality (str, optional): Modality used for RGB plots. Defaults to first modality in data_root.keys().
             rgb_indices (list[str], optional): Indices of RGB channels. Defaults to [0, 1, 2].
             allow_missing_modalities (bool, optional): Allow missing modalities during data loading. Defaults to False.
-                TODO: Currently not implemented on a data module level!
             allow_substring_file_names (bool, optional): Allow substrings during sample identification by adding
                 image or label grep to the sample prefixes. If False, treats sample prefixes as full file names.
                 If True and no split file is provided, considers the file stem as prefix, otherwise the full file name.

--- a/tests/datamodules/test_genericmultimodaldatamodule.py
+++ b/tests/datamodules/test_genericmultimodaldatamodule.py
@@ -8,10 +8,10 @@ from utils import create_dummy_tiff
 def dummy_multimodal_data(tmp_path: Path) -> Path:
     root = tmp_path / "generic_multimodal"
     root.mkdir(parents=True, exist_ok=True)
-    train_data_dir = root / "train" / "mod1"
-    val_data_dir = root / "val" / "mod1"
-    test_data_dir = root / "test" / "mod1"
-    predict_data_dir = root / "predict" / "mod1"
+    train_data_dir = root / "train" / "input"
+    val_data_dir = root / "val" / "input"
+    test_data_dir = root / "test" / "input"
+    predict_data_dir = root / "predict" / "input"
     for p in [train_data_dir, val_data_dir, test_data_dir, predict_data_dir]:
         p.mkdir(parents=True, exist_ok=True)
     train_label_dir = root / "train" / "labels"
@@ -25,22 +25,37 @@ def dummy_multimodal_data(tmp_path: Path) -> Path:
     pixel_values_label = [0, 1]
 
     create_dummy_tiff(
-        path=str(train_data_dir / "sample1.tif"),
+        path=str(train_data_dir / "sample1_mod1.tif"),
         shape=shape_img,
         pixel_values=pixel_values_image
     )
     create_dummy_tiff(
-        path=str(val_data_dir / "sample1.tif"),
+        path=str(val_data_dir / "sample1_mod1.tif"),
         shape=shape_img,
         pixel_values=pixel_values_image
     )
     create_dummy_tiff(
-        path=str(test_data_dir / "sample1.tif"),
+        path=str(test_data_dir / "sample1_mod1.tif"),
         shape=shape_img,
         pixel_values=pixel_values_image
     )
     create_dummy_tiff(
-        path=str(predict_data_dir / "sample1.tif"),
+        path=str(predict_data_dir / "sample1_mod1.tif"),
+        shape=shape_img,
+        pixel_values=pixel_values_image
+    )
+    create_dummy_tiff(
+        path=str(train_data_dir / "sample1_mod2.tif"),
+        shape=shape_img,
+        pixel_values=pixel_values_image
+    )
+    create_dummy_tiff(
+        path=str(val_data_dir / "sample1_mod2.tif"),
+        shape=shape_img,
+        pixel_values=pixel_values_image
+    )
+    create_dummy_tiff(
+        path=str(test_data_dir / "sample1_mod2.tif"),
         shape=shape_img,
         pixel_values=pixel_values_image
     )
@@ -66,10 +81,10 @@ def dummy_multimodal_data(tmp_path: Path) -> Path:
 def test_generic_multimodal_datamodule(dummy_multimodal_data: Path):
     from terratorch.datamodules.generic_multimodal_data_module import GenericMultiModalDataModule
 
-    train_data_root = {"mod1": str(dummy_multimodal_data / "train" / "mod1")}
-    val_data_root = {"mod1": str(dummy_multimodal_data / "val" / "mod1")}
-    test_data_root = {"mod1": str(dummy_multimodal_data / "test" / "mod1")}
-    predict_data_root = {"mod1": str(dummy_multimodal_data / "predict" / "mod1")}
+    train_data_root = {"mod1": str(dummy_multimodal_data / "train" / "input")}
+    val_data_root = {"mod1": str(dummy_multimodal_data / "val" / "input")}
+    test_data_root = {"mod1": str(dummy_multimodal_data / "test" / "input")}
+    predict_data_root = {"mod1": str(dummy_multimodal_data / "predict" / "input")}
     train_label_root = str(dummy_multimodal_data / "train" / "labels")
     val_label_root = str(dummy_multimodal_data / "val" / "labels")
     test_label_root = str(dummy_multimodal_data / "test" / "labels")
@@ -85,6 +100,8 @@ def test_generic_multimodal_datamodule(dummy_multimodal_data: Path):
         val_data_root=val_data_root,
         test_data_root=test_data_root,
         predict_data_root=predict_data_root,
+        image_grep={"mod1": "*_mod1.tif"},
+        label_grep="*tif",
         train_label_data_root=train_label_root,
         val_label_data_root=val_label_root,
         test_label_data_root=test_label_root,
@@ -115,6 +132,72 @@ def test_generic_multimodal_datamodule(dummy_multimodal_data: Path):
     dm.setup("predict")
     predict_loader = dm.predict_dataloader()
     predict_batch = next(iter(predict_loader))
-    assert "image" in predict_batch, "Missing key 'image' in test batch"
+    assert "image" in predict_batch, "Missing key 'image' in predict batch"
+
+    gc.collect()
+
+
+def test_generic_multimodal_datamodule_missing_mod(dummy_multimodal_data: Path):
+    from terratorch.datamodules.generic_multimodal_data_module import GenericMultiModalDataModule
+
+    train_data_root = {"mod1": str(dummy_multimodal_data / "train" / "input"),
+                       "mod2": str(dummy_multimodal_data / "train" / "input")}
+    val_data_root = {"mod1": str(dummy_multimodal_data / "val" / "input"),
+                     "mod2": str(dummy_multimodal_data / "val" / "input")}
+    test_data_root = {"mod1": str(dummy_multimodal_data / "test" / "input"),
+                      "mod2": str(dummy_multimodal_data / "test" / "input")}
+    predict_data_root = {"mod1": str(dummy_multimodal_data / "predict" / "input"),
+                         "mod2": str(dummy_multimodal_data / "predict" / "input")}
+    train_label_root = str(dummy_multimodal_data / "train" / "labels")
+    val_label_root = str(dummy_multimodal_data / "val" / "labels")
+    test_label_root = str(dummy_multimodal_data / "test" / "labels")
+    means = {"mod1": [0.0, 0.0, 0.0], "mod2": [0.0, 0.0, 0.0]}
+    stds = {"mod1": [1.0, 1.0, 1.0], "mod2": [1.0, 1.0, 1.0]}
+
+    dm = GenericMultiModalDataModule(
+        modalities=["mod1", "mod2"],
+        task="segmentation",
+        num_classes=2,
+        batch_size=2,
+        train_data_root=train_data_root,
+        val_data_root=val_data_root,
+        test_data_root=test_data_root,
+        predict_data_root=predict_data_root,
+        image_grep={"mod1": "*_mod1.tif", "mod2": "*_mod2.tif"},
+        train_label_data_root=train_label_root,
+        val_label_data_root=val_label_root,
+        test_label_data_root=test_label_root,
+        allow_missing_modalities=True,
+        allow_substring_file_names=True,
+        means=means,
+        stds=stds,
+        drop_last=False,
+        num_workers=0,
+        pin_memory=False,
+    )
+
+    dm.setup("fit")
+    train_loader = dm.train_dataloader()
+    train_batch = next(iter(train_loader))
+    assert "mod1" in train_batch["image"], "Missing key 'mod1' in train batch['image']"
+    assert "mod2" in train_batch["image"], "Missing key 'mod2' in train batch['image']"
+    assert "mask" in train_batch, "Missing key 'mask' in train batch"
+    dm.setup("validate")
+    val_loader = dm.val_dataloader()
+    val_batch = next(iter(val_loader))
+    assert "mod1" in val_batch["image"], "Missing key 'mod1' in validation batch['image']"
+    assert "mod2" in val_batch["image"], "Missing key 'mod2' in validation batch['image']"
+    assert "mask" in val_batch, "Missing key 'mask' in validation batch"
+    dm.setup("test")
+    test_loader = dm.test_dataloader()
+    test_batch = next(iter(test_loader))
+    assert "mod1" in test_batch["image"], "Missing key 'mod1' in test batch['image']"
+    assert "mod2" in test_batch["image"], "Missing key 'mod2' in test batch['image']"
+    assert "mask" in test_batch, "Missing key 'mask' in test batch"
+    dm.setup("predict")
+    predict_loader = dm.predict_dataloader()
+    predict_batch = next(iter(predict_loader))
+    assert "mod1" in predict_batch["image"], "Missing key 'mod1' in predict batch['image']"
+    # mod2 not expected to test allow_missing_modalities
 
     gc.collect()


### PR DESCRIPTION
- Fallback to `data_root` for `label_data_root` is not working as `data_root` is a dict and not a path. Removed.
- Add `allow_missing_modalities` to the datamodule and to tests.