### PR TITLE
It's necessary to overwrite the `find_classes` method the generic scalar dataset

### DIFF
--- a/terratorch/datamodules/generic_scalar_label_data_module.py
+++ b/terratorch/datamodules/generic_scalar_label_data_module.py
@@ -3,6 +3,7 @@
 """
 This module contains generic data modules for instantiation at runtime.
 """
+
 import logging
 from collections.abc import Callable, Iterable
 from pathlib import Path
@@ -26,9 +27,11 @@ from .utils import check_dataset_stackability
 
 logger = logging.getLogger("terratorch")
 
+
 def wrap_in_compose_is_list(transform_list):
     # set check shapes to false because of the multitemporal case
     return A.Compose(transform_list, is_check_shapes=False) if isinstance(transform_list, Iterable) else transform_list
+
 
 class Normalize(Callable):
     def __init__(self, means, stds):
@@ -225,6 +228,7 @@ class GenericNonGeoClassificationDataModule(NonGeoDataModule):
             self.predict_dataset = self.dataset_class(
                 self.predict_root,
                 self.num_classes,
+                require_label=False,
                 dataset_bands=self.predict_dataset_bands,
                 output_bands=self.output_bands,
                 constant_scale=self.constant_scale,

--- a/terratorch/datasets/generic_scalar_label_dataset.py
+++ b/terratorch/datasets/generic_scalar_label_dataset.py
@@ -36,6 +36,7 @@ class GenericScalarLabelDataset(NonGeoDataset, ImageFolder, ABC):
         self,
         data_root: Path,
         split: Path | None = None,
+        require_label: bool = True,
         ignore_split_file_extensions: bool = True,  # noqa: FBT001, FBT002
         allow_substring_split_file: bool = True,  # noqa: FBT001, FBT002
         rgb_indices: list[int] | None = None,
@@ -76,6 +77,8 @@ class GenericScalarLabelDataset(NonGeoDataset, ImageFolder, ABC):
                 Defaults to False.
         """
         self.split_file = split
+        self.split = split
+        self.require_label = require_label
         self.image_files = sorted(glob.glob(os.path.join(data_root, "**"), recursive=True))
         self.image_files = [f for f in self.image_files if not os.path.isdir(f)]
         self.constant_scale = constant_scale
@@ -184,7 +187,7 @@ class GenericScalarLabelDataset(NonGeoDataset, ImageFolder, ABC):
         if self.transforms:
             image = self.transforms(image=image)["image"]  # albumentations returns dict
 
-        if label:
+        if self.require_label:
             output = {
                 "image": image,
                 "label": label,  # samples is an attribute of ImageFolder. Contains a tuple of (Path, Target)
@@ -232,6 +235,7 @@ class GenericNonGeoClassificationDataset(GenericScalarLabelDataset):
         data_root: Path,
         num_classes: int,
         split: Path | None = None,
+        require_label: bool = True,
         ignore_split_file_extensions: bool = True,  # noqa: FBT001, FBT002
         allow_substring_split_file: bool = True,  # noqa: FBT001, FBT002
         rgb_indices: list[str] | None = None,
@@ -274,6 +278,7 @@ class GenericNonGeoClassificationDataset(GenericScalarLabelDataset):
         super().__init__(
             data_root,
             split=split,
+            require_label=require_label,
             ignore_split_file_extensions=ignore_split_file_extensions,
             allow_substring_split_file=allow_substring_split_file,
             rgb_indices=rgb_indices,


### PR DESCRIPTION
When the prediction directory is not organised in subdirectories, this method must be overwritten in order to allow the files be loaded. 