### PR TITLE
add TerraMind embedding generation example notebook

### DIFF
--- a/examples/notebooks/TerraMindEmbedding.ipynb
+++ b/examples/notebooks/TerraMindEmbedding.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Embedding Generation\n",
+    "This example performs generation of a single embedding vector from a 16x16 Sentinel-2 RGB image patch with TerraMind."
+   ],
+   "id": "7b6872e1a26474b6"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:31:55.376441Z",
+     "start_time": "2025-09-02T16:31:55.373533Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import torch\n",
+    "import rioxarray as rxr\n",
+    "from huggingface_hub import hf_hub_download\n",
+    "from terratorch.registry import BACKBONE_REGISTRY\n",
+    "\n",
+    "# Select device\n",
+    "if torch.cuda.is_available():\n",
+    "    device = 'cuda'\n",
+    "elif torch.backends.mps.is_available():\n",
+    "    device = 'mps'\n",
+    "else:\n",
+    "    device = 'cpu'"
+   ],
+   "id": "6f31289e8bb79bc8",
+   "outputs": [],
+   "execution_count": 37
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:31:57.667824Z",
+     "start_time": "2025-09-02T16:31:56.806419Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# build model\n",
+    "model = BACKBONE_REGISTRY.build(\n",
+    "    \"terramind_v1_base\",\n",
+    "    # modalities=[\"S2L2A\"], # all S2 bands\n",
+    "    modalities=[\"S2RGB\"], # S2 RGB bands\n",
+    "    pretrained=True,\n",
+    ")\n",
+    "\n",
+    "model = model.to(device)"
+   ],
+   "id": "f539a8e5118a9f8c",
+   "outputs": [],
+   "execution_count": 38
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:31:58.413671Z",
+     "start_time": "2025-09-02T16:31:58.409717Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "model.eval()",
+   "id": "5b4a3e0c6719a23",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TerraMindViT(\n",
+       "  (encoder_embeddings): ModuleDict(\n",
+       "    (untok_sen2rgb@224): ImageEncoderEmbedding(\n",
+       "      (proj): Linear(in_features=768, out_features=768, bias=False)\n",
+       "    )\n",
+       "  )\n",
+       "  (encoder): ModuleList(\n",
+       "    (0-11): 12 x Block(\n",
+       "      (norm1): LayerNorm()\n",
+       "      (attn): Attention(\n",
+       "        (qkv): Linear(in_features=768, out_features=2304, bias=False)\n",
+       "        (attn_drop): Dropout(p=0.0, inplace=False)\n",
+       "        (proj): Linear(in_features=768, out_features=768, bias=False)\n",
+       "        (proj_drop): Dropout(p=0.0, inplace=False)\n",
+       "      )\n",
+       "      (drop_path): Identity()\n",
+       "      (norm2): LayerNorm()\n",
+       "      (mlp): GatedMlp(\n",
+       "        (fc1): Linear(in_features=768, out_features=2048, bias=False)\n",
+       "        (act): SiLU()\n",
+       "        (fc2): Linear(in_features=2048, out_features=768, bias=False)\n",
+       "        (fc3): Linear(in_features=768, out_features=2048, bias=False)\n",
+       "      )\n",
+       "    )\n",
+       "  )\n",
+       "  (encoder_norm): LayerNorm()\n",
+       "  (tokenizer): ModuleDict()\n",
+       ")"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 39
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": 48,
+   "source": [
+    "# Download image if necessary\n",
+    "image_path = Path('examples/S2L2A/Santiago.tif')\n",
+    "if not image_path.exists():\n",
+    "    hf_hub_download(repo_id='ibm-esa-geospatial/Examples', filename='S2L2A/Santiago.tif', repo_type='dataset', local_dir='examples/')"
+   ],
+   "id": "e553c977d92bccf0"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:34:37.033781Z",
+     "start_time": "2025-09-02T16:34:36.947309Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Open image\n",
+    "data = rxr.open_rasterio(image_path).values\n",
+    "# Select RGB image of dimension 16x16\n",
+    "data = data[[4,3,2], 0:16, 0:16]\n",
+    "data.shape"
+   ],
+   "id": "179c25ceca558745",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 16, 16)"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 53
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:34:47.369125Z",
+     "start_time": "2025-09-02T16:34:47.360831Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "#create torch input\n",
+    "input = torch.tensor(data, dtype=torch.float, device=device).unsqueeze(0)\n",
+    "input.shape"
+   ],
+   "id": "a1c59e0fa1068b11",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 3, 16, 16])"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 55
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Retrieve Embedding",
+   "id": "2d082befe0f70d5"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:35:31.359759Z",
+     "start_time": "2025-09-02T16:35:31.333304Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# we evaluate the pretrained model on the embedding and retrieve the last layer\n",
+    "embedding = model(input)[-1]"
+   ],
+   "id": "d30e42abb5255efd",
+   "outputs": [],
+   "execution_count": 57
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-09-02T16:35:38.407518Z",
+     "start_time": "2025-09-02T16:35:38.405290Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# print output embedding\n",
+    "embedding.shape"
+   ],
+   "id": "b014a6c72e6f442f",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 768])"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 58
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "4f4ea2ee352a6a23"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Created an example notebook to generate TerraMind embeddings based on @Isabelle-Wittmann's implementation:
https://github.com/IBM/terratorch/blob/main/examples/confs/embedding_generation/terramind_embeddings.yaml
https://github.com/IBM/terratorch/blob/main/terratorch/tasks/embedding_generation.py

The notebook loads the example `S2L2A/Santiago.tif` file from huggingface, then selects a single 16x16, RBG patch from that image, and outputs the embedded vector of dimension `768`.

The notebook can be found here:
https://github.com/GieziJo/terratorch/blob/TerraMindEmbeddingGenerationNotebook/examples/notebooks/TerraMindEmbedding.ipynb