### PR TITLE
Adding missing dependencies `dask` and `tokenizers`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
   "h5netcdf",
   "pytest-sugar",
   "dask",
+  "tokenizers"
 ]
 
 


### PR DESCRIPTION
The package `diffusers` is already included among the mandatory dependencies and don't need to be in `test`. 