### PR TITLE
Fix tokenizer imports and make it optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
   "huggingface_hub",
   "tifffile",
   "python-box",
-  "diffusers>=0.30.0",
   "wandb",
   "termcolor",
   "numba",
@@ -90,7 +89,8 @@ test = [
   "pytest-coverage",
   "coverage-badge",
   "peft>=0.15.0",
-  "diffusers>=0.30.0",
+  "diffusers<=0.34.0",
+  "tokenizers",
   "dask",
   "wandb",
 ]

--- a/tests/test_reconstructions.py
+++ b/tests/test_reconstructions.py
@@ -37,8 +37,9 @@ def test_prithvi_mae_reconstruction(model_name):
 def test_terramind_v01_generation(model_name):
     try:
         import diffusers
+        import tokenizers
     except ImportError:
-        pytest.skip("diffusers not installed")
+        pytest.skip("diffusers or tokenizers not installed")
 
     model = FULL_MODEL_REGISTRY.build(
         model_name,
@@ -75,8 +76,9 @@ def test_terramind_v01_generation(model_name):
 def test_terramind_generation(model_name):
     try:
         import diffusers
+        import tokenizers
     except ImportError:
-        pytest.skip("diffusers not installed")
+        pytest.skip("diffusers or tokenizers not installed")
 
     model = FULL_MODEL_REGISTRY.build(
         model_name,


### PR DESCRIPTION
tokenizers and diffusers are optional packages needed for TerraMind generations.