### PR TITLE
Update timm import

### DIFF
--- a/terratorch/models/backbones/mmearth_convnextv2.py
+++ b/terratorch/models/backbones/mmearth_convnextv2.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 
 import torch
 import torch.nn as nn
-from timm.models.layers import trunc_normal_, DropPath
+from timm.layers import trunc_normal_, DropPath
 from torch import Tensor
 
 from .norm_layers import LayerNorm, GRN


### PR DESCRIPTION
Package timm==1.0.17 leads to following warning:
```text
FutureWarning: Importing from timm.models.layers is deprecated, please import via timm.layers
  warnings.warn(f"Importing from {__name__} is deprecated, please import via timm.layers", FutureWarning)
```

Updating import. This warning will still occur because of old imports in Sunya which needs to be updated as well.