### PR TITLE
Update test workflow to ignore changes in the integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ on:
       - '**/*.png'
       - '**/*.txt'
       - '**/*.ipynb'
+      - 'integrationtests/**/*'
   pull_request:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - '**/*.png'
       - '**/*.txt'
       - '**/*.ipynb'
+      - 'integrationtests/**/*'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It isn't necessary to run automatic tests for changes executed for the integration tests, which run in an independent manner. 