### PR TITLE
Fix condition initialization tokenizer file

### DIFF
--- a/terratorch/models/backbones/terramind/tokenizer/tokenizer_register.py
+++ b/terratorch/models/backbones/terramind/tokenizer/tokenizer_register.py
@@ -459,7 +459,7 @@ def terramind_v1_coords_tokenizer(pretrained=True, tokenizer_file=None, *args, *
                       f"\nMake sure to install `pip install tokenizers`.")
         raise import_error_tokenizers
 
-    if pretrained and tokenizer_file is not None:
+    if pretrained and tokenizer_file is None:
         tokenizer_file = hf_hub_download(
             repo_id=pretrained_weights["terramind_v1_coords_tokenizer"]["hf_hub_id"],
             filename=pretrained_weights["terramind_v1_coords_tokenizer"]["hf_hub_filename"]


### PR DESCRIPTION
Ensure the tokenizer file is downloaded instead of falling back to the blank WordPiece tokenizer.