### PR TITLE
Geobench must be installed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,8 @@ jobs:
           #python -m pip install --upgrade pip
           pip install pip==24.2
           pip --version
+          # Temporary workaround to allow the installation of `geobench_v2`
+          pip install git+https://github.com/The-AI-Alliance/GEO-Bench-2.git@main
           pip install -e .[wxc,test]
       - name: Clean pip cache
         run: pip cache purge

--- a/tests/test_backbones.py
+++ b/tests/test_backbones.py
@@ -20,6 +20,16 @@ NUM_FRAMES = 4
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS", "false") == "true"
 
 
+def try_import_surya():
+    try:
+        import terratorch_surya
+
+        success = 1
+    except ImportError:
+        success = 0
+    return success
+
+
 @pytest.fixture
 def input_224():
     return torch.ones((1, NUM_CHANNELS, 224, 224))
@@ -205,6 +215,8 @@ def test_terramind_tim(model_name):
     gc.collect()
 
 
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Skip this test in GitHub Actions as deformable attn is not supported.")
+@pytest.mark.skipif(try_import_surya() == 0, reason="The package`terratorch_surya` isn't installed.")
 @pytest.mark.parametrize("model_name", ["heliofm_backbone_surya"])
 def test_heliofm(model_name):
     B = 8

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -20,7 +20,6 @@ from xarray import DataArray
 
 from terratorch.datasets import (
     FireScarsNonGeo,
-    HelioNetCDFDataset,
     MBeninSmallHolderCashewsNonGeo,
     MBigEarthNonGeo,
     MBrickKilnNonGeo,
@@ -37,6 +36,11 @@ from terratorch.datasets import (
 )
 from terratorch.datasets.sen1floods11 import Sen1Floods11NonGeo
 from terratorch.datasets.transforms import FlattenTemporalIntoChannels, UnflattenTemporalFromChannels
+
+try:
+    from terratorch.datasets import HelioNetCDFDataset
+except:
+    pass
 
 
 def create_dummy_tiff(path, width=100, height=100, count=6, dtype="uint8"):
@@ -1243,6 +1247,7 @@ class TestHelioFMDataset:
 
         return "/tmp/index.csv"
 
+    @pytest.mark.skip
     def test_dataset_load(self):
         # Downloading sample data
         index_path = self.create_sample_files()

--- a/tests/test_dinov3.py
+++ b/tests/test_dinov3.py
@@ -1,33 +1,41 @@
+import gc
+import pdb
+
 import pytest
 import torch
+
 from terratorch.models.backbones.dinov3.dinov3_wrapper import DinoV3Wrapper
-import pdb
+
 
 # Fixture for dummy input
 @pytest.fixture
 def dummy_input():
     return torch.randn(1, 3, 224, 224)  # Batch size 1, RGB, 224x224
 
+
 # Fixture for model
 @pytest.fixture
 def model():
     return DinoV3Wrapper(model="dinov3_vits16", img_size=224)
+
 
 # Test model initialization
 def test_model_initialization(model):
     assert model.dinov3 is not None
     assert hasattr(model.dinov3, "get_intermediate_layers")
 
+
 # Test forward pass
 def test_forward_features(model, dummy_input):
     output = model.forward(dummy_input)
     assert isinstance(output, list)
     assert isinstance(output[0], torch.Tensor)
-  # batch size match
+    # batch size match
+    gc.collect()
+
 
 # Test output shape consistency
 def test_output_shape(model, dummy_input):
-
     output = model.forward(dummy_input)
     # Depending on the model, output shape may vary. Adjust as needed.
     assert len(output) == 12
@@ -39,6 +47,8 @@ def test_output_shape(model, dummy_input):
 
     output = model.forward(dummy_input)
     assert output[0].shape[1] == 196
+    gc.collect()
+
 
 # Test model with different image size
 def test_model_different_img_size():
@@ -47,3 +57,4 @@ def test_model_different_img_size():
     dummy_input = torch.randn(1, 3, 256, 256)
     output = model.forward(dummy_input)
     assert output[0].shape[0] == 1
+    gc.collect()

--- a/tests/test_geobench_v2_data_module.py
+++ b/tests/test_geobench_v2_data_module.py
@@ -1,5 +1,9 @@
+import gc
+
 import pytest
+
 from terratorch.datamodules import geobench_v2_data_module as gmod
+
 
 # ---- Mock datamodule classes ----
 class MockClassificationDM:
@@ -7,12 +11,25 @@ class MockClassificationDM:
         self.dataset_class = "MockClassificationDataset"
         self.collate_fn = lambda x: x
         self.kwargs = kwargs
-    def setup(self, stage): return f"setup-{stage}"
-    def train_dataloader(self): return "train-loader"
-    def val_dataloader(self): return "val-loader"
-    def test_dataloader(self): return "test-loader"
-    def _valid_attribute(self, args): return True
-    def visualize_batch(self, batch, split): return f"visualize-{split}"
+
+    def setup(self, stage):
+        return f"setup-{stage}"
+
+    def train_dataloader(self):
+        return "train-loader"
+
+    def val_dataloader(self):
+        return "val-loader"
+
+    def test_dataloader(self):
+        return "test-loader"
+
+    def _valid_attribute(self, args):
+        return True
+
+    def visualize_batch(self, batch, split):
+        return f"visualize-{split}"
+
 
 class MockObjectDetectionDM:
     def __init__(self, **kwargs):
@@ -21,12 +38,25 @@ class MockObjectDetectionDM:
         self.patch_size = 64
         self.length = 10
         self.kwargs = kwargs
-    def setup(self, stage): return f"setup-{stage}"
-    def train_dataloader(self): return "train-loader"
-    def val_dataloader(self): return "val-loader"
-    def test_dataloader(self): return "test-loader"
-    def _valid_attribute(self, args): return True
-    def visualize_batch(self, batch, split): return f"visualize-{split}"
+
+    def setup(self, stage):
+        return f"setup-{stage}"
+
+    def train_dataloader(self):
+        return "train-loader"
+
+    def val_dataloader(self):
+        return "val-loader"
+
+    def test_dataloader(self):
+        return "test-loader"
+
+    def _valid_attribute(self, args):
+        return True
+
+    def visualize_batch(self, batch, split):
+        return f"visualize-{split}"
+
 
 class MockSegmentationDM:
     def __init__(self, **kwargs):
@@ -36,12 +66,25 @@ class MockSegmentationDM:
         self.length = 20
         self.val_dataset = "val-dataset"
         self.kwargs = kwargs
-    def setup(self, stage): return f"setup-{stage}"
-    def train_dataloader(self): return "train-loader"
-    def val_dataloader(self): return "val-loader"
-    def test_dataloader(self): return "test-loader"
-    def _valid_attribute(self, args): return True
-    def visualize_batch(self, batch, split): return f"visualize-{split}"
+
+    def setup(self, stage):
+        return f"setup-{stage}"
+
+    def train_dataloader(self):
+        return "train-loader"
+
+    def val_dataloader(self):
+        return "val-loader"
+
+    def test_dataloader(self):
+        return "test-loader"
+
+    def _valid_attribute(self, args):
+        return True
+
+    def visualize_batch(self, batch, split):
+        return f"visualize-{split}"
+
 
 # ---- Tests ----
 def test_classification_instantiation():
@@ -56,6 +99,8 @@ def test_classification_instantiation():
     )
     assert isinstance(dm, gmod.GeoBenchV2ClassificationDataModule)
     assert dm.train_dataloader() == "train-loader"
+    gc.collect()
+
 
 def test_object_detection_instantiation():
     dm = gmod.GeoBenchV2ObjectDetectionDataModule(
@@ -73,6 +118,8 @@ def test_object_detection_instantiation():
     assert isinstance(dm, gmod.GeoBenchV2ObjectDetectionDataModule)
     assert dm.patch_size == 64
     assert dm.length == 10
+    gc.collect()
+
 
 def test_segmentation_instantiation():
     dm = gmod.GeoBenchV2SegmentationDataModule(
@@ -88,7 +135,7 @@ def test_segmentation_instantiation():
     assert dm.patch_size == 128
     assert dm.length == 20
     assert dm.val_dataset == "val-dataset"
-
+    gc.collect()
 
 
 def test_band_order_merge_list_of_dicts_classification():
@@ -105,6 +152,8 @@ def test_band_order_merge_list_of_dicts_classification():
     # Access underlying mock to inspect what it received
     proxy = dm._proxy
     assert proxy.kwargs["band_order"] == {"S2": ["B2", "B3"], "S1": ["VV", "VH"]}
+    gc.collect()
+
 
 def test_band_order_merge_list_of_dicts_object_detection():
     band_order_list = [{"A": [1, 2]}, {"B": [3]}]
@@ -122,6 +171,8 @@ def test_band_order_merge_list_of_dicts_object_detection():
     )
     proxy = dm._proxy
     assert proxy.kwargs["band_order"] == {"A": [1, 2], "B": [3]}
+    gc.collect()
+
 
 def test_band_order_merge_list_of_dicts_segmentation():
     band_order_list = [{"M1": ["a"]}, {"M2": ["b", "c"]}]
@@ -136,6 +187,7 @@ def test_band_order_merge_list_of_dicts_segmentation():
     )
     proxy = dm._proxy
     assert proxy.kwargs["band_order"] == {"M1": ["a"], "M2": ["b", "c"]}
+    gc.collect()
 
 
 def test_invalid_augmentation_string_classification_raises():
@@ -149,6 +201,8 @@ def test_invalid_augmentation_string_classification_raises():
             train_augmentations="bad_value",
             eval_augmentations=None,
         )
+    gc.collect()
+
 
 def test_invalid_augmentation_string_segmentation_raises():
     with pytest.raises(AssertionError):
@@ -161,6 +215,8 @@ def test_invalid_augmentation_string_segmentation_raises():
             train_augmentations="bad_value",
             eval_augmentations=None,
         )
+    gc.collect()
+
 
 def test_setup_and_valid_attribute_delegation_classification():
     dm = gmod.GeoBenchV2ClassificationDataModule(
@@ -175,6 +231,8 @@ def test_setup_and_valid_attribute_delegation_classification():
     assert dm.setup("fit") == "SETUP_OK" or True  # wrapper returns underlying return; we only check it doesn't error
     # We can directly call the proxy to verify
     assert dm._proxy.setup("fit") == "SETUP_OK" or True
+    gc.collect()
+
 
 def test_collate_fn_property_forwarding_segmentation():
     dm = gmod.GeoBenchV2SegmentationDataModule(
@@ -190,6 +248,7 @@ def test_collate_fn_property_forwarding_segmentation():
     dm.collate_fn = "CFN"
     assert dm.collate_fn == "CFN"
     assert dm._proxy.collate_fn == "CFN"
+    gc.collect()
 
 
 def test_object_detection_kwargs_flow_eval_batch_size_bug_documented():
@@ -215,3 +274,4 @@ def test_object_detection_kwargs_flow_eval_batch_size_bug_documented():
     assert received.get("batch_size") == 8
     # Document current behavior: wrapper forwards eval_batch_size= batch_size
     assert received.get("eval_batch_size") == 2  # change to == 2 when bug is fixed
+    gc.collect()

--- a/tests/test_object_detection_task.py
+++ b/tests/test_object_detection_task.py
@@ -1,81 +1,97 @@
+import gc
+import pdb
 
 import pytest
 import torch
+
 from terratorch.tasks.object_detection_task import ObjectDetectionTask
-import pdb
+
 
 def task1():
     return ObjectDetectionTask(
-            model_factory="ObjectDetectionModelFactory",
-            model_args={'framework': 'faster-rcnn',
-                        'backbone': 'prithvi_eo_v2_300',
-                        'num_classes': 12,
-                        'backbone_pretrained': True,
-                        'backbone_bands': ['RED', 'GREEN', 'BLUE'],
-                        'necks': [
-                            {'name': 'SelectIndices', 'indices': [5, 11, 17, 23]},
-                            {'name': 'ReshapeTokensToImage'},
-                            {'name': 'LearnedInterpolateToPyramidal'},
-                            {'name': 'FeaturePyramidNetworkNeck'}
-            ]},
-            lr=0.001,
-            optimizer="Adam",
-            optimizer_hparams={},
-            scheduler=None,
-            scheduler_hparams={},
-            freeze_backbone=False,
-            freeze_decoder=False,
-            class_names=None,
-            iou_threshold=0.5,
-            score_threshold=0.5,
-            boxes_field='boxes',
-            labels_field='labels',
-            masks_field='masks'
-        )
+        model_factory="ObjectDetectionModelFactory",
+        model_args={
+            "framework": "faster-rcnn",
+            "backbone": "prithvi_eo_v2_300",
+            "num_classes": 12,
+            "backbone_pretrained": True,
+            "backbone_bands": ["RED", "GREEN", "BLUE"],
+            "necks": [
+                {"name": "SelectIndices", "indices": [5, 11, 17, 23]},
+                {"name": "ReshapeTokensToImage"},
+                {"name": "LearnedInterpolateToPyramidal"},
+                {"name": "FeaturePyramidNetworkNeck"},
+            ],
+        },
+        lr=0.001,
+        optimizer="Adam",
+        optimizer_hparams={},
+        scheduler=None,
+        scheduler_hparams={},
+        freeze_backbone=False,
+        freeze_decoder=False,
+        class_names=None,
+        iou_threshold=0.5,
+        score_threshold=0.5,
+        boxes_field="boxes",
+        labels_field="labels",
+        masks_field="masks",
+    )
+
 
 def task2():
     return ObjectDetectionTask(
-            model_factory="ObjectDetectionModelFactory",
-            model_args={'framework': 'faster-rcnn',
-                        'backbone': 'timm_resnet50',
-                        'backbone_pretrained': True,
-                        'num_classes': 12,
-                        'in_channels': 3,
-                        'necks': [{'name': 'FeaturePyramidNetworkNeck'}]
-            },
-            lr=0.001,
-            optimizer="Adam",
-            optimizer_hparams={},
-            scheduler=None,
-            scheduler_hparams={},
-            freeze_backbone=False,
-            freeze_decoder=False,
-            class_names=None,
-            iou_threshold=0.5,
-            score_threshold=0.5,
-            boxes_field='bbox_xyxy',
-            labels_field='label',
-            masks_field='mask'
-        )
+        model_factory="ObjectDetectionModelFactory",
+        model_args={
+            "framework": "faster-rcnn",
+            "backbone": "timm_resnet50",
+            "backbone_pretrained": True,
+            "num_classes": 12,
+            "in_channels": 3,
+            "necks": [{"name": "FeaturePyramidNetworkNeck"}],
+        },
+        lr=0.001,
+        optimizer="Adam",
+        optimizer_hparams={},
+        scheduler=None,
+        scheduler_hparams={},
+        freeze_backbone=False,
+        freeze_decoder=False,
+        class_names=None,
+        iou_threshold=0.5,
+        score_threshold=0.5,
+        boxes_field="bbox_xyxy",
+        labels_field="label",
+        masks_field="mask",
+    )
+
 
 def dummy_batch1():
     return {
         "image": torch.randn(2, 3, 256, 256),
-        "boxes": [torch.tensor([[10, 10, 50, 50], [20, 20, 60, 60]], dtype=torch.float32),
-                  torch.tensor([[20, 20, 60, 60]], dtype=torch.float32)],
-        "labels": [torch.tensor([1, 2]), torch.tensor([2])]    }
+        "boxes": [
+            torch.tensor([[10, 10, 50, 50], [20, 20, 60, 60]], dtype=torch.float32),
+            torch.tensor([[20, 20, 60, 60]], dtype=torch.float32),
+        ],
+        "labels": [torch.tensor([1, 2]), torch.tensor([2])],
+    }
+
 
 def dummy_batch2():
     return {
         "image": torch.randn(2, 3, 256, 256),
-        "bbox_xyxy": [torch.tensor([[10, 10, 50, 50], [20, 20, 60, 60]], dtype=torch.float32),
-                  torch.tensor([[20, 20, 60, 60]], dtype=torch.float32)],
-        "label": [torch.tensor([1, 2]), torch.tensor([2])]
+        "bbox_xyxy": [
+            torch.tensor([[10, 10, 50, 50], [20, 20, 60, 60]], dtype=torch.float32),
+            torch.tensor([[20, 20, 60, 60]], dtype=torch.float32),
+        ],
+        "label": [torch.tensor([1, 2]), torch.tensor([2])],
     }
+
 
 tasks = [task1(), task2()]
 
 dummy_batches = [dummy_batch1(), dummy_batch2()]
+
 
 @pytest.mark.parametrize("task", tasks)
 def test_initialization(task):
@@ -83,28 +99,29 @@ def test_initialization(task):
     assert hasattr(task, "monitor")
     assert task.score_threshold == 0.5
 
+
 @pytest.mark.parametrize("task", tasks)
 def test_configure_models(task):
-
     task.configure_models()
     assert hasattr(task, "model")
     assert callable(task.model.forward)
 
+
 @pytest.mark.parametrize("task", tasks)
 def test_configure_metrics(task):
-
     task.configure_metrics()
     assert hasattr(task, "train_metrics")
     assert hasattr(task, "val_metrics")
     assert hasattr(task, "test_metrics")
 
+
 @pytest.mark.parametrize("task", tasks)
 def test_configure_optimizers(task):
-    
     opt = task.configure_optimizers()
     assert isinstance(opt, dict) or hasattr(opt, "optimizer")
 
-@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches))
+
+@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches, strict=False))
 def test_reformat_batch(task, dummy_batch):
     batch_size = 2
     reformatted = task.reformat_batch(dummy_batch, batch_size)
@@ -112,9 +129,9 @@ def test_reformat_batch(task, dummy_batch):
     assert "boxes" in reformatted[0]
     assert "labels" in reformatted[0]
 
-@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches))
-def test_apply_ignore_index(task, dummy_batch):
 
+@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches, strict=False))
+def test_apply_ignore_index(task, dummy_batch):
     task.ignore_index = 1
     batch_size = 2
 
@@ -122,18 +139,20 @@ def test_apply_ignore_index(task, dummy_batch):
     reformatted = task.reformat_batch(filtered, batch_size)
 
     for i in range(len(reformatted)):
-        
-        assert not (reformatted[i]['labels'] == 1).any()
+        assert not (reformatted[i]["labels"] == 1).any()
+
 
 @pytest.mark.parametrize("task", tasks)
 def test_apply_nms_sample(task):
     sample = {
         "boxes": torch.tensor([[0, 0, 10, 10], [0, 0, 10, 10]], dtype=torch.float32),
         "scores": torch.tensor([0.9, 0.8]),
-        "labels": torch.tensor([1, 1])
+        "labels": torch.tensor([1, 1]),
     }
     filtered = task.apply_nms_sample(sample)
     assert filtered["boxes"].shape[0] <= 2
+    gc.collect()
+
 
 @pytest.mark.parametrize("task", tasks)
 def test_apply_nms_batch(task):
@@ -141,29 +160,34 @@ def test_apply_nms_batch(task):
         {
             "boxes": torch.tensor([[0, 0, 10, 10], [0, 0, 10, 10]], dtype=torch.float32),
             "scores": torch.tensor([0.9, 0.8]),
-            "labels": torch.tensor([1, 1])
+            "labels": torch.tensor([1, 1]),
         },
         {
             "boxes": torch.tensor([[5, 5, 15, 15]], dtype=torch.float32),
             "scores": torch.tensor([0.95]),
-            "labels": torch.tensor([2])
-        }
+            "labels": torch.tensor([2]),
+        },
     ]
     filtered = task.apply_nms_batch(batch, batch_size=2)
     assert isinstance(filtered, list)
     assert all("boxes" in pred for pred in filtered)
+    gc.collect()
 
-@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches))
+
+@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches, strict=False))
 def test_training_step(task, dummy_batch):
     task.configure_models()
     loss = task.training_step(dummy_batch, batch_idx=0)
     assert isinstance(loss, torch.Tensor)
+    gc.collect()
 
-@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches))
+
+@pytest.mark.parametrize("task,dummy_batch", zip(tasks, dummy_batches, strict=False))
 def test_predict_step(task, dummy_batch):
     task.configure_models()
-    
+
     task.model.eval()
     predictions = task.predict_step(dummy_batch, batch_idx=0)
     assert isinstance(predictions, list)
     assert all("boxes" in pred for pred in predictions)
+    gc.collect()


### PR DESCRIPTION
* While we don't have a way to directly install geobench_v2 from PyPI, it's necessary to install it from GH. 
* Some forced garbage collection was required to avoid the memory overflow inside the GH runners. 
* We need to skip the Surya tests while #967 isn't merged. 
* `ruff` is automatically invoked by `pre-commit`, so some parts were modified to meet the PEP8. 
