### PR TITLE
Separating vllm dependencies from tests dependencies

### DIFF
--- a/integrationtests/vllm_tests_set.sh
+++ b/integrationtests/vllm_tests_set.sh
@@ -13,7 +13,7 @@ source ${VENV_NAME}/bin/activate
 
 cd terratorch
 
-uv pip install --no-cache-dir -e .[test]
+uv pip install --no-cache-dir -e .[test,vllm,vllm_test]
 
 pytest -s -v integrationtests/vLLM/ 2>&1
 pytest_ret=$?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,9 +90,6 @@ test = [
   "dask",
   "wandb",
   "pytest-sugar",
-  "vllm>=0.10.2",
-  "pillow",
-  "imagehash",
   "numba",
   "hdf5plugin",
   "h5netcdf",
@@ -128,6 +125,16 @@ peft = [
 geobenchv2 = [
   "geobench_v2",
   "mlflow",
+]
+
+vllm = [
+  "geobenchv2",
+  "vllm==0.11.0",
+]
+
+vllm_test = [
+  "pillow",
+  "imagehash",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR creates two new optional dependencies groups:
- `vllm`: it only installs vLLM 0.11.0. This should be only installed by people using terratorch + vLLM
- `vllm_test`: it installs the packages for testing the vLLM io_processor plugin in Terratorch

The benefit is that the main test pipeline is currently separated from the vLLM one. This means that so far we have been installing vLLM for all tests even though they were not required. Also, it allows people who want to use vLLM + TT to quickly only get the necessary libraries for running their applications.