### PR TITLE
update type hint in generic multimodal datamodule

### DIFF
--- a/terratorch/datamodules/generic_multimodal_data_module.py
+++ b/terratorch/datamodules/generic_multimodal_data_module.py
@@ -196,7 +196,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         rgb_indices: list[int] | None = None,
         allow_substring_file_names: bool = True,
         class_names: list[str] | None = None,
-        constant_scale: dict[float] = None,
+        constant_scale: dict[str, float] = None,
         train_transform: dict | A.Compose | None | list[A.BasicTransform] = None,
         val_transform: dict | A.Compose | None | list[A.BasicTransform] = None,
         test_transform: dict | A.Compose | None | list[A.BasicTransform] = None,
@@ -283,7 +283,7 @@ class GenericMultiModalDataModule(NonGeoDataModule):
                 If True and no split file is provided, considers the file stem as prefix, otherwise the full file name.
                 Defaults to True.
             class_names (list[str], optional): Names of the classes. Defaults to None.
-            constant_scale (dict[float]): Factor to multiply data values by, provided as a dictionary with modalities as
+            constant_scale (dict[str, float]): Factor to multiply data values by, provided as a dictionary with modalities as
                 keys. Can be subset of all modalities. Defaults to None.
             train_transform (Albumentations.Compose | dict | None): Albumentations transform to be applied to all image
                 modalities. Should end with ToTensorV2() and not include normalization. The transform is not applied to 

--- a/terratorch/datasets/generic_multimodal_dataset.py
+++ b/terratorch/datasets/generic_multimodal_dataset.py
@@ -583,7 +583,7 @@ class GenericMultimodalSegmentationDataset(GenericMultimodalDataset):
             output_bands (dict[list], optional): Bands that should be output by the dataset as named by dataset_bands,
                 provided as a dictionary with modality keys. Can be subset of all modalities. Defaults to None.
             class_names (list[str], optional): Names of the classes. Defaults to None.
-            constant_scale (dict[float]): Factor to multiply data values by, provided as a dictionary with modalities as
+            constant_scale (dict[str, float]): Factor to multiply data values by, provided as a dictionary with modalities as
                 keys. Can be subset of all modalities. Defaults to None.
             transform (Albumentations.Compose | dict | None): Albumentations transform to be applied to all image
                 modalities (transformation are shared between image modalities, e.g., similar crop or rotation).
@@ -746,7 +746,7 @@ class GenericMultimodalPixelwiseRegressionDataset(GenericMultimodalDataset):
         allow_substring_file_names: bool = False,
         dataset_bands: dict[list] | None = None,
         output_bands: dict[list] | None = None,
-        constant_scale: dict[float] = 1.0,
+        constant_scale: dict[str, float] = 1.0,
         transform: A.Compose | dict | None = None,
         no_data_replace: float | None = None,
         no_label_replace: float | None = None,


### PR DESCRIPTION
The generic multimodal module expects `constant_scale` to be a dict of modalities, but the type hint was defined as `constant_scale: dict[float] ` instead of `constant_scale: dict[str, float]` which caused an error when using a correctly configured yaml config in CLI workflow.