### PR TITLE
Deprecated classification head warning

### DIFF
--- a/terratorch/models/heads/__init__.py
+++ b/terratorch/models/heads/__init__.py
@@ -1,11 +1,14 @@
 # Copyright contributors to the Terratorch project
+
 import warnings
 from terratorch.models.heads.scalar_head import ScalarHead
 from terratorch.models.heads.regression_head import RegressionHead
 from terratorch.models.heads.segmentation_head import SegmentationHead
 
 # TODO: Remove in a version v1.3 or later
-warnings.warn("ClassificationHead is deprecated. Use ScalarHead instead", DeprecationWarning)
-ClassificationHead = ScalarHead
+class ClassificationHead(ScalarHead):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("ClassificationHead is deprecated. Use ScalarHead instead", DeprecationWarning)
+        super().__init__(*args, **kwargs)
 
 __all__ = ["ScalarHead", "RegressionHead", "SegmentationHead"]

--- a/terratorch/models/scalar_output_model.py
+++ b/terratorch/models/scalar_output_model.py
@@ -128,6 +128,3 @@ class ScalarOutputModel(Model, SegmentationModel):
             raise Exception(msg)
             
         return ScalarHead(input_embed_dim, **head_kwargs)
-        
-       
-            


### PR DESCRIPTION
Update warning for deprecated classification head. Only raise it when the head is used.