### PR TITLE
Cleaning up cache in two stages to avoid OSError

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,8 @@ jobs:
           #python -m pip install --upgrade pip
           pip install pip==24.2
           pip --version
+          pip install -e .
+          pip cache purge
           pip install -e .[wxc,test,surya,geobenchv2]
       - name: Clean pip cache
         run: pip cache purge


### PR DESCRIPTION
This should avoid this error for `main`: https://github.com/terrastackai/terratorch/actions/runs/20095263987/job/57894689829#step:4:881