### PR TITLE
Always generated float16 dummy inputs (vLLM default)

### DIFF
--- a/terratorch/vllm/utils.py
+++ b/terratorch/vllm/utils.py
@@ -46,7 +46,7 @@ class DummyDataGenerator():
         mm_data = {}
         for input_name,input in self.input_definition.data.items():
             if input.type == InputTypeEnum.tensor:
-                mm_data[input_name] = torch.full(input.shape,1.0,dtype=torch.get_default_dtype())
+                mm_data[input_name] = torch.full(input.shape,1.0,dtype=torch.float16)
         return mm_data
 
 def lookup_task_name(class_path):


### PR DESCRIPTION
Revert previous change to make sure dummy inputs are always in float16 type.