### PR TITLE
extend mlp decoder to 2d inputs

### DIFF
--- a/terratorch/models/decoders/mlp_decoder.py
+++ b/terratorch/models/decoders/mlp_decoder.py
@@ -30,10 +30,15 @@ class MLPDecoder(nn.Module):
         self.activation = getattr(nn, activation)()
 
     def forward(self, x: list[Tensor]):
-
         data_ = torch.cat(x, axis=1)
-        data_ = data_.permute(0, 2, 3, 1)
-        data_ = self.activation(self.hidden_layer(data_))
-        data_ = data_.permute(0, 3, 1, 2)
 
-        return data_ 
+        if data_.dim() == 4:
+            data_ = data_.permute(0, 2, 3, 1)
+            data_ = self.activation(self.hidden_layer(data_))
+            data_ = data_.permute(0, 3, 1, 2)
+            return data_
+
+        if data_.dim() == 2:
+            return self.activation(self.hidden_layer(data_))
+
+        raise ValueError(f"Expected 2D or 4D, got {tuple(data_.shape)}")


### PR DESCRIPTION
Mlp decoder currently expects 4d (B,C,H,W) inputs. This extends the Mlp decoder to also operate on 2d inputs (B,C). Functionality for 4d inputs remains unchanged.