### PR TITLE
Updated TM IO Processor Plugin to support the latest vLLM release

### DIFF
--- a/integrationtests/vLLM/config.py
+++ b/integrationtests/vLLM/config.py
@@ -1,42 +1,51 @@
 models = {
     "prithvi_300m_sen1floods11": {
         "location": "ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11",
+        "io_processor_plugin": "terratorch_segmentation",
     },
     "prithvi_300m_burnscars": {
         "location": "ibm-nasa-geospatial/Prithvi-EO-2.0-300M-BurnScars",
+        "io_processor_plugin": "terratorch_segmentation",
+    },
+    "terramind_base_flood": {
+        "location": "ibm-esa-geospatial/TerraMind-base-Flood",
+        "io_processor_plugin": "terratorch_tm_segmentation"
     }
 }
 
 inputs = {
-    "india_url_in_base64_out":
-        {
-            "image_url": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/India_900498_S2Hand.tif",
-            "indices": [1, 2, 3, 8, 11, 12],
-            "data_format": "url",
-            "out_data_format": "b64_json",
-        },
-    "valencia_url_in_base64_out":
-        {
-            "image_url": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/valencia_example_2024-10-26.tiff",
-            "data_format": "url",
-            "out_data_format": "b64_json",
-        },
-    "valencia_url_in_path_out":
-        {
-            "image_url": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/valencia_example_2024-10-26.tiff",
-            "data_format": "url",
-            "out_data_format": "path",
-        },
-    "burnscars_url_in_base64_out":
-    {
+    "india_url_in_base64_out": {
+        "image_url": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/India_900498_S2Hand.tif",
+        "indices": [1, 2, 3, 8, 11, 12],
+        "data_format": "url",
+        "out_data_format": "b64_json",
+    },
+    "valencia_url_in_base64_out": {
+        "image_url": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/valencia_example_2024-10-26.tiff",
+        "data_format": "url",
+        "out_data_format": "b64_json",
+    },
+    "valencia_url_in_path_out": {
+        "image_url": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/valencia_example_2024-10-26.tiff",
+        "data_format": "url",
+        "out_data_format": "path",
+    },
+    "burnscars_url_in_base64_out": {
         "image_url": "https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-2.0-300M-BurnScars/resolve/main/examples/subsetted_512x512_HLS.S30.T10SEH.2018190.v1.4_merged.tif",
         "data_format": "url",
         "out_data_format": "b64_json",
-
     },
-    "burnscars_url_in_path_out":
-    {
+    "burnscars_url_in_path_out": {
         "image_url": "https://huggingface.co/ibm-nasa-geospatial/Prithvi-EO-2.0-300M-BurnScars/resolve/main/examples/subsetted_512x512_HLS.S30.T10SEH.2018190.v1.4_merged.tif",
+        "data_format": "url",
+        "out_data_format": "path",
+    },
+    "terramind_base_flood_url_in_path_out": {
+        "image_url": {
+            "DEM": "https://huggingface.co/datasets/christian-pinto/TestTerraMindDataset/resolve/main/EMSR354_23_37LFH_DEM.tif",
+            "S1RTC": "https://huggingface.co/datasets/christian-pinto/TestTerraMindDataset/resolve/main/EMSR354_23_37LFH_S1RTC.zarr.zip",
+            "S2L2A": "https://huggingface.co/datasets/christian-pinto/TestTerraMindDataset/resolve/main/EMSR354_23_37LFH_S2L2A.zarr.zip",
+        },
         "data_format": "url",
         "out_data_format": "path",
     }

--- a/integrationtests/vLLM/test_segmentation_io_processor.py
+++ b/integrationtests/vLLM/test_segmentation_io_processor.py
@@ -14,13 +14,16 @@ from .config import models, inputs
 # Each model has a different output depending also on the plugin
 models_output = {
     "prithvi_300m_sen1floods11": {
-            "india_url_in_base64_out": "f7dc282de2c36942",
-            "valencia_url_in_base64_out": "aa6d92ad25926a5e",
-            "valencia_url_in_path_out": "aa6d92ad25926a5e",
-        },
+        "india_url_in_base64_out": "f7dc282de2c36942",
+        "valencia_url_in_base64_out": "aa6d92ad25926a5e",
+        "valencia_url_in_path_out": "aa6d92ad25926a5e",
+    },
     "prithvi_300m_burnscars": {
         "burnscars_url_in_base64_out": "c17c4f602ea7b616",
         "burnscars_url_in_path_out": "c17c4f602ea7b616"
+    },
+    "terramind_base_flood": {
+        "terramind_base_flood_url_in_path_out": "dc25fd8e31cc0a72",
     }
 }
 
@@ -64,10 +67,10 @@ def get_server(server):
 )
 def test_serving_segmentation_plugin(get_server, model_name, input_name):
     model = models[model_name]["location"]
+    io_processor_plugin = models[model_name]["io_processor_plugin"]
     input = inputs[input_name]
 
     image_url = input["image_url"]
-    plugin = "terratorch_segmentation"
     server_args = [
         "--skip-tokenizer-init",
         "--enforce-eager",
@@ -76,7 +79,7 @@ def test_serving_segmentation_plugin(get_server, model_name, input_name):
         "--max-num-seqs",
         "8",
         "--io-processor-plugin",
-        plugin,
+        io_processor_plugin,
         "--model-impl",
         "terratorch",
         "--enable-mm-embeds"


### PR DESCRIPTION
This PR updates the Terramind IO Processor segmentation plugin to support the latest vLLM (0.13.) and adds an integration test for TerraMind serving with vLLM.
