### PR TITLE
Fixed logic for tortilla file vs data roots

### DIFF
--- a/terratorch/datamodules/generic_pixel_wise_data_module.py
+++ b/terratorch/datamodules/generic_pixel_wise_data_module.py
@@ -213,13 +213,11 @@ class GenericNonGeoSegmentationDataModule(NonGeoDataModule):
 
         self.check_stackability = check_stackability
 
-        if tortilla_file is None and not all([
-            train_data_root, 
-            val_data_root, 
-            test_data_root
-            ]
-        ):
-            raise MisconfigurationException("Either provide tortilla_file OR all train/val/test roots.")
+        if tortilla_file is not None and any([train_data_root, val_data_root, test_data_root]):
+            raise MisconfigurationException(
+                "Cannot provide both tortilla_file and train_data_root/val_data_root/test_data_root. "
+                "Use tortilla_file OR data roots (not both)."
+            )
 
         self.tortilla_df = tacoreader.load(str(tortilla_file)) if tortilla_file is not None else None
 


### PR DESCRIPTION
Fix for regression caused by #1059, see https://github.com/terrastackai/terratorch/pull/1059/changes#r2783659205

Changes parameter validation so that the check instead makes sure that either a tortilla_file or any of the train/test/val data roots are used.

## Testing Requirements
- [x] **Manual Testing:** I have verified these changes in a local/dev environment.
- [ ] **Reviewer Sign-off:** By checking this box, the reviewer confirms they have pulled this branch and ran the test suite locally.

