### PR TITLE
Add Rasteret dataset/datamodule integration to TerraTorch

### DIFF
--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -79,6 +79,57 @@ You can also do this outside of config files! Simply instantiate the data module
     This has to be done as the `transforms` argument is passed through `**kwargs` in TorchGeo, making it difficult to instantiate with LightningCLI.
     See more details below.
 
+## Using Rasteret Collections
+
+TerraTorch now includes a native Rasteret integration:
+
+- `terratorch.datasets.RasteretDataset`
+- `terratorch.datamodules.RasteretDataModule`
+
+Install Rasteret support with:
+
+```bash
+pip install "terratorch[rasteret]"
+```
+
+Python usage:
+
+```python
+import rasteret
+from terratorch.datamodules import RasteretDataModule
+
+collection = rasteret.build(
+    "earthsearch/sentinel-2-l2a",
+    name="s2-example",
+    bbox=(77.5, 12.9, 77.7, 13.1),
+    date_range=("2024-01-01", "2024-03-31"),
+)
+
+datamodule = RasteretDataModule(
+    collection=collection,
+    bands=["B04", "B03", "B02"],
+    batch_size=8,
+    patch_size=256,
+    length=1000,
+)
+```
+
+Config-file usage can load a pre-built collection by name:
+
+```yaml
+data:
+  class_path: terratorch.datamodules.RasteretDataModule
+  init_args:
+    collection_name: s2-example
+    bands:
+      - B04
+      - B03
+      - B02
+    batch_size: 8
+    patch_size: 256
+    length: 1000
+```
+
 
 ## Generic datasets and data modules
 
@@ -93,6 +144,5 @@ In case you want to use TerraTorch on your specific data, we invite you to devel
 ## Transforms
 The [transforms module](../package/transforms.md) provides a set of specialized image transformations designed to manipulate spatial, temporal, and multimodal data efficiently. 
 These transformations allow for greater flexibility when working with multi-temporal, multi-channel, and multi-modal datasets, ensuring that data can be formatted appropriately for different model architectures.
-
 
 

--- a/docs/package/datamodules.md
+++ b/docs/package/datamodules.md
@@ -46,6 +46,8 @@
 
 :::terratorch.datamodules.pastis
 
+:::terratorch.datamodules.rasteret
+
 :::terratorch.datamodules.sen1floods11
 
 :::terratorch.datamodules.sen4agrinet

--- a/docs/package/datasets.md
+++ b/docs/package/datasets.md
@@ -44,6 +44,8 @@
 
 :::terratorch.datasets.pastis
 
+:::terratorch.datasets.rasteret
+
 :::terratorch.datasets.sen1floods11
 
 :::terratorch.datasets.sen4agrinet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,10 @@ test = [
 #  "granitewxc",  # Currently fails of pypi version conflics
 ]
 
+rasteret = [
+  "rasteret>=0.3.7",
+]
+
 surya = [
   "numba",
   "hdf5plugin",

--- a/terratorch/datamodules/__init__.py
+++ b/terratorch/datamodules/__init__.py
@@ -30,6 +30,7 @@ from terratorch.datamodules.m_so2sat import MSo2SatNonGeoDataModule
 from terratorch.datamodules.multi_temporal_crop_classification import MultiTemporalCropClassificationDataModule
 from terratorch.datamodules.open_sentinel_map import OpenSentinelMapDataModule
 from terratorch.datamodules.pastis import PASTISDataModule
+from terratorch.datamodules.rasteret import RasteretDataModule
 
 try:
     wxc_present = True
@@ -107,6 +108,7 @@ __all__ = [
     "OpenEarthMapNonGeoDataModule",
     "OpenSentinelMapDataModule",
     "PASTISDataModule",
+    "RasteretDataModule",
     "Sen4AgriNetDataModule",
     "GenericMultiModalDataModule",
     "mVHR10DataModule",

--- a/terratorch/datamodules/rasteret.py
+++ b/terratorch/datamodules/rasteret.py
@@ -1,0 +1,178 @@
+# Copyright contributors to the Terratorch project
+
+"""Rasteret-backed TerraTorch geospatial datamodule."""
+
+from collections.abc import Callable, Sequence
+from importlib import import_module
+from typing import Any
+
+from pyproj import CRS
+from torchgeo.datamodules import GeoDataModule
+from torchgeo.datasets.utils import lazy_import
+from torchgeo.samplers import GridGeoSampler, RandomBatchGeoSampler
+
+from terratorch.datasets.rasteret import RasteretDataset
+
+
+class RasteretDataModule(GeoDataModule):
+    """A ``GeoDataModule`` for Rasteret collections."""
+
+    def __init__(
+        self,
+        bands: Sequence[str],
+        collection: Any | None = None,
+        collection_name: str | None = None,
+        train_collection: Any | None = None,
+        train_collection_name: str | None = None,
+        val_collection: Any | None = None,
+        val_collection_name: str | None = None,
+        test_collection: Any | None = None,
+        test_collection_name: str | None = None,
+        predict_collection: Any | None = None,
+        predict_collection_name: str | None = None,
+        batch_size: int = 4,
+        patch_size: int | tuple[int, int] = 256,
+        length: int = 100,
+        num_workers: int = 0,
+        crs: CRS | None = None,
+        res: float | tuple[float, float] | None = None,
+        train_transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        val_transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        test_transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        predict_transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        train_geometries: Any = None,
+        val_geometries: Any = None,
+        test_geometries: Any = None,
+        predict_geometries: Any = None,
+        geometries_crs: int = 4326,
+        cache: bool = True,  # noqa: FBT001, FBT002
+        time_series: bool = False,  # noqa: FBT001, FBT002
+        is_image: bool = True,  # noqa: FBT001, FBT002
+        max_concurrent: int = 50,
+        cloud_config: Any = None,
+        backend: Any = None,
+        allow_resample: bool = False,  # noqa: FBT001, FBT002
+        label_field: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a Rasteret-backed data module."""
+        if not bands:
+            msg = "At least one band is required"
+            raise ValueError(msg)
+
+        super().__init__(
+            dataset_class=RasteretDataset,
+            batch_size=batch_size,
+            patch_size=patch_size,
+            length=length,
+            num_workers=num_workers,
+            **kwargs,
+        )
+
+        self.bands = list(bands)
+        self.collection = collection
+        self.collection_name = collection_name
+        self.train_collection = train_collection
+        self.train_collection_name = train_collection_name
+        self.val_collection = val_collection
+        self.val_collection_name = val_collection_name
+        self.test_collection = test_collection
+        self.test_collection_name = test_collection_name
+        self.predict_collection = predict_collection
+        self.predict_collection_name = predict_collection_name
+
+        self.crs = crs
+        self.res = res
+        self.train_transform = train_transform
+        self.val_transform = val_transform
+        self.test_transform = test_transform
+        self.predict_transform = predict_transform
+
+        self.train_geometries = train_geometries
+        self.val_geometries = val_geometries
+        self.test_geometries = test_geometries
+        self.predict_geometries = predict_geometries
+        self.geometries_crs = geometries_crs
+
+        self.cache = cache
+        self.time_series = time_series
+        self.is_image = is_image
+        self.max_concurrent = max_concurrent
+        self.cloud_config = cloud_config
+        self.backend = backend
+        self.allow_resample = allow_resample
+        self.label_field = label_field
+
+        self._collections_cache: dict[str, Any] = {}
+
+    def _load_collection_by_name(self, collection_name: str) -> Any:
+        if collection_name not in self._collections_cache:
+            lazy_import("rasteret")
+            rasteret = import_module("rasteret")
+            self._collections_cache[collection_name] = rasteret.load(collection_name)
+        return self._collections_cache[collection_name]
+
+    def _resolve_collection(self, split: str) -> Any:
+        split_collection = getattr(self, f"{split}_collection")
+        if split_collection is not None:
+            return split_collection
+
+        split_collection_name = getattr(self, f"{split}_collection_name")
+        if split_collection_name is not None:
+            return self._load_collection_by_name(split_collection_name)
+
+        if self.collection is not None:
+            return self.collection
+
+        if self.collection_name is not None:
+            return self._load_collection_by_name(self.collection_name)
+
+        msg = (
+            f"No Rasteret collection configured for '{split}'. "
+            "Set collection/collection_name or split-specific equivalents."
+        )
+        raise ValueError(msg)
+
+    def _make_dataset(
+        self,
+        split: str,
+        transform: Callable[[dict[str, Any]], dict[str, Any]] | None,
+        geometries: Any,
+    ) -> RasteretDataset:
+        return self.dataset_class(
+            collection=self._resolve_collection(split),
+            bands=self.bands,
+            crs=self.crs,
+            res=self.res,
+            transforms=transform,
+            cache=self.cache,
+            time_series=self.time_series,
+            is_image=self.is_image,
+            max_concurrent=self.max_concurrent,
+            cloud_config=self.cloud_config,
+            backend=self.backend,
+            allow_resample=self.allow_resample,
+            label_field=self.label_field,
+            geometries=geometries,
+            geometries_crs=self.geometries_crs,
+        )
+
+    def setup(self, stage: str | None) -> None:
+        """Set up datasets and samplers."""
+        if stage in (None, "fit"):
+            self.train_dataset = self._make_dataset("train", self.train_transform, self.train_geometries)
+            self.train_batch_sampler = RandomBatchGeoSampler(
+                self.train_dataset, self.patch_size, self.batch_size, self.length
+            )
+
+        if stage in (None, "fit", "validate"):
+            self.val_dataset = self._make_dataset("val", self.val_transform, self.val_geometries)
+            self.val_sampler = GridGeoSampler(self.val_dataset, self.patch_size, self.patch_size)
+
+        if stage in (None, "test"):
+            self.test_dataset = self._make_dataset("test", self.test_transform, self.test_geometries)
+            self.test_sampler = GridGeoSampler(self.test_dataset, self.patch_size, self.patch_size)
+
+        if stage in (None, "predict"):
+            self.predict_dataset = self._make_dataset("predict", self.predict_transform, self.predict_geometries)
+            self.predict_sampler = GridGeoSampler(self.predict_dataset, self.patch_size, self.patch_size)

--- a/terratorch/datasets/__init__.py
+++ b/terratorch/datasets/__init__.py
@@ -43,6 +43,7 @@ from terratorch.datasets.open_sentinel_map import OpenSentinelMap
 # miscellaneous datasets
 from terratorch.datasets.openearthmap import OpenEarthMapNonGeo
 from terratorch.datasets.pastis import PASTIS
+from terratorch.datasets.rasteret import RasteretDataset
 
 # GenericNonGeoRegressionDataset,
 from terratorch.datasets.sen1floods11 import Sen1Floods11NonGeo
@@ -100,6 +101,7 @@ __all__ = (
     "MNeonTreeNonGeo",
     "OpenSentinelMap",
     "PASTIS",
+    "RasteretDataset",
     "Sen4AgriNet",
     "WSF2019",
     "WSFEvolution",

--- a/terratorch/datasets/rasteret.py
+++ b/terratorch/datasets/rasteret.py
@@ -1,0 +1,122 @@
+# Copyright contributors to the Terratorch project
+
+"""Rasteret-backed TorchGeo raster dataset."""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import torch
+from pyproj import CRS
+from torchgeo.datasets.geo import RasterDataset, Sample
+from torchgeo.datasets.utils import lazy_import
+
+
+class RasteretDataset(RasterDataset):
+    """A ``RasterDataset`` that delegates reads to Rasteret collections."""
+
+    def __init__(
+        self,
+        collection: Any,
+        bands: Sequence[str],
+        crs: CRS | None = None,
+        res: float | tuple[float, float] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
+        cache: bool = True,  # noqa: FBT001, FBT002
+        time_series: bool = False,  # noqa: FBT001, FBT002
+        is_image: bool = True,  # noqa: FBT001, FBT002
+        max_concurrent: int = 50,
+        cloud_config: Any = None,
+        backend: Any = None,
+        allow_resample: bool = False,  # noqa: FBT001, FBT002
+        label_field: str | None = None,
+        geometries: Any = None,
+        geometries_crs: int = 4326,
+    ) -> None:
+        """Initialize a ``RasteretDataset`` from a Rasteret collection."""
+        lazy_import("rasteret")
+
+        if not bands:
+            msg = "At least one band is required"
+            raise ValueError(msg)
+
+        to_torchgeo_dataset = getattr(collection, "to_torchgeo_dataset", None)
+        if not callable(to_torchgeo_dataset):
+            msg = "collection must be a rasteret.Collection with to_torchgeo_dataset(...)"
+            raise TypeError(msg)
+
+        target_crs: int | None = None
+        if crs is not None:
+            epsg = crs.to_epsg()
+            if epsg is None:
+                msg = "RasteretDataset requires an EPSG CRS"
+                raise ValueError(msg)
+            target_crs = int(epsg)
+
+        self._delegate = to_torchgeo_dataset(
+            bands=list(bands),
+            is_image=is_image,
+            allow_resample=allow_resample,
+            label_field=label_field,
+            geometries=geometries,
+            geometries_crs=geometries_crs,
+            transforms=transforms,
+            max_concurrent=max_concurrent,
+            cloud_config=cloud_config,
+            backend=backend,
+            time_series=time_series,
+            target_crs=target_crs,
+        )
+
+        self.paths = ""
+        self.bands = tuple(bands)
+        self.all_bands = tuple(bands)
+        self.transforms = transforms
+        self.cache = cache
+        self.time_series = time_series
+        self.is_image = is_image
+        self.separate_files = False
+        self.band_indexes = None
+        self.index = self._delegate.index
+        self._res = self._delegate.res
+
+        if res is not None:
+            self.res = res
+
+    def __getitem__(self, index: Any) -> Sample:
+        """Retrieve a sample indexed by spatiotemporal slice."""
+        return self._delegate[index]
+
+    @property
+    def crs(self) -> CRS:
+        """Coordinate reference system of the dataset."""
+        return self._delegate.crs
+
+    @crs.setter
+    def crs(self, _new_crs: CRS) -> None:
+        """Reject post-init CRS changes."""
+        msg = "RasteretDataset CRS is fixed after construction; create a new dataset with crs=..."
+        raise AttributeError(msg)
+
+    @property
+    def res(self) -> tuple[float, float]:
+        """Resolution of the dataset in units of CRS."""
+        return self._delegate.res
+
+    @res.setter
+    def res(self, new_res: float | tuple[float, float]) -> None:
+        """Change dataset resolution."""
+        self._delegate.res = new_res
+        self._res = self._delegate.res
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """The dtype used for outputs."""
+        if self.is_image:
+            return torch.float32
+        return torch.long
+
+    def close(self) -> None:
+        """Close Rasteret background resources if supported by delegate."""
+        close = getattr(self._delegate, "close", None)
+        if callable(close):
+            close()

--- a/tests/datamodules/test_rasteret.py
+++ b/tests/datamodules/test_rasteret.py
@@ -1,0 +1,134 @@
+from datetime import UTC, datetime
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+import shapely
+import torch
+from pyproj import CRS
+from torchgeo.samplers import GridGeoSampler, RandomBatchGeoSampler
+
+from terratorch.datamodules import RasteretDataModule
+
+
+class _DummyRasteretGeoDataset:
+    def __init__(self) -> None:
+        interval_index = pd.IntervalIndex.from_tuples(
+            [(datetime(2024, 6, 1, tzinfo=UTC), datetime(2024, 6, 1, tzinfo=UTC))],
+            closed="both",
+            name="datetime",
+        )
+        self.index = gpd.GeoDataFrame(
+            {"rid": [0]},
+            index=interval_index,
+            geometry=[shapely.box(399960, 5390220, 400600, 5390860)],
+            crs=CRS.from_epsg(32632),
+        )
+        self._res = (10.0, 10.0)
+
+    @property
+    def crs(self) -> CRS:
+        return CRS.from_user_input(self.index.crs)
+
+    @property
+    def res(self) -> tuple[float, float]:
+        return self._res
+
+    @res.setter
+    def res(self, new_res: float | tuple[float, float]) -> None:
+        if isinstance(new_res, int | float):
+            self._res = (float(new_res), float(new_res))
+            return
+        self._res = new_res
+
+    def __getitem__(self, _index):
+        return {
+            "image": torch.ones((3, 16, 16), dtype=torch.float32),
+            "bounds": torch.zeros(9, dtype=torch.float64),
+            "transform": torch.zeros(9, dtype=torch.float64),
+        }
+
+
+@pytest.fixture(autouse=True)
+def _disable_rasteret_import(monkeypatch):
+    monkeypatch.setattr("terratorch.datasets.rasteret.lazy_import", lambda _name: None)
+    monkeypatch.setattr("terratorch.datamodules.rasteret.lazy_import", lambda _name: None)
+
+
+@pytest.fixture
+def collection():
+    class _Collection:
+        def to_torchgeo_dataset(self, **_kwargs):
+            return _DummyRasteretGeoDataset()
+
+    return _Collection()
+
+
+def test_setup_fit_builds_train_and_val(collection):
+    dm = RasteretDataModule(
+        collection=collection,
+        bands=["B04", "B03", "B02"],
+        batch_size=2,
+        patch_size=16,
+        length=4,
+    )
+    dm.setup("fit")
+
+    assert dm.train_dataset is not None
+    assert dm.val_dataset is not None
+    assert isinstance(dm.train_batch_sampler, RandomBatchGeoSampler)
+    assert isinstance(dm.val_sampler, GridGeoSampler)
+
+
+def test_setup_test_and_predict(collection):
+    dm = RasteretDataModule(
+        collection=collection,
+        bands=["B04"],
+        batch_size=2,
+        patch_size=16,
+        length=4,
+    )
+
+    dm.setup("test")
+    assert dm.test_dataset is not None
+    assert isinstance(dm.test_sampler, GridGeoSampler)
+
+    dm.setup("predict")
+    assert dm.predict_dataset is not None
+    assert isinstance(dm.predict_sampler, GridGeoSampler)
+
+
+def test_missing_collection_raises():
+    dm = RasteretDataModule(
+        bands=["B04"],
+        batch_size=2,
+        patch_size=16,
+        length=4,
+    )
+
+    with pytest.raises(ValueError, match="No Rasteret collection"):
+        dm.setup("fit")
+
+
+def test_collection_name_loads_once(monkeypatch, collection):
+    class _RasteretModule:
+        def __init__(self):
+            self.load_calls = []
+
+        def load(self, collection_name: str):
+            self.load_calls.append(collection_name)
+            return collection
+
+    fake_module = _RasteretModule()
+    monkeypatch.setattr("terratorch.datamodules.rasteret.import_module", lambda _name: fake_module)
+
+    dm = RasteretDataModule(
+        collection_name="demo-collection",
+        bands=["B04"],
+        batch_size=2,
+        patch_size=16,
+        length=4,
+    )
+    dm.setup("fit")
+
+    assert fake_module.load_calls == ["demo-collection"]

--- a/tests/test_rasteret_dataset.py
+++ b/tests/test_rasteret_dataset.py
@@ -1,0 +1,146 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+import shapely
+import torch
+from pyproj import CRS
+
+from terratorch.datasets.rasteret import RasteretDataset
+
+
+class _DummyRasteretGeoDataset:
+    def __init__(self) -> None:
+        interval_index = pd.IntervalIndex.from_tuples(
+            [(datetime(2024, 6, 1, tzinfo=UTC), datetime(2024, 6, 1, tzinfo=UTC))],
+            closed="both",
+            name="datetime",
+        )
+        self.index = gpd.GeoDataFrame(
+            {"rid": [0]},
+            index=interval_index,
+            geometry=[shapely.box(399960, 5390220, 400600, 5390860)],
+            crs=CRS.from_epsg(32632),
+        )
+        self._res = (10.0, 10.0)
+        self.closed = False
+
+    @property
+    def crs(self) -> CRS:
+        return CRS.from_user_input(self.index.crs)
+
+    @property
+    def res(self) -> tuple[float, float]:
+        return self._res
+
+    @res.setter
+    def res(self, new_res: float | tuple[float, float]) -> None:
+        if isinstance(new_res, int | float):
+            self._res = (float(new_res), float(new_res))
+            return
+        self._res = new_res
+
+    def __getitem__(self, _index):
+        return {
+            "image": torch.ones((3, 16, 16), dtype=torch.float32),
+            "bounds": torch.zeros(9, dtype=torch.float64),
+            "transform": torch.zeros(9, dtype=torch.float64),
+        }
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _disable_rasteret_import(monkeypatch):
+    monkeypatch.setattr("terratorch.datasets.rasteret.lazy_import", lambda _name: None)
+
+
+@pytest.fixture
+def collection():
+    delegate = _DummyRasteretGeoDataset()
+    mock = MagicMock()
+    mock.to_torchgeo_dataset.return_value = delegate
+    return mock
+
+
+def test_init_forwards_collection_adapter(collection):
+    ds = RasteretDataset(collection=collection, bands=["B04", "B03", "B02"])
+    call = collection.to_torchgeo_dataset.call_args
+
+    assert call is not None
+    assert call.kwargs["bands"] == ["B04", "B03", "B02"]
+    assert call.kwargs["target_crs"] is None
+    assert ds.bands == ("B04", "B03", "B02")
+    assert ds.crs == CRS.from_epsg(32632)
+
+
+def test_init_with_crs_and_res(collection):
+    ds = RasteretDataset(
+        collection=collection,
+        bands=["B04"],
+        crs=CRS.from_epsg(4326),
+        res=0.0001,
+    )
+    call = collection.to_torchgeo_dataset.call_args
+
+    assert call is not None
+    assert call.kwargs["target_crs"] == 4326
+    assert ds.res == (0.0001, 0.0001)
+
+
+def test_init_requires_bands(collection):
+    with pytest.raises(ValueError, match="At least one band"):
+        RasteretDataset(collection=collection, bands=[])
+
+
+def test_init_requires_callable_adapter():
+    class _CollectionWithoutAdapter:
+        to_torchgeo_dataset = "not-callable"
+
+    with pytest.raises(TypeError, match="to_torchgeo_dataset"):
+        RasteretDataset(collection=_CollectionWithoutAdapter(), bands=["B04"])
+
+
+def test_non_epsg_crs_rejected(collection):
+    non_epsg = CRS.from_wkt(
+        'ENGCRS["foo",EDATUM["Unknown"],CS[Cartesian,2],'
+        'AXIS["x",east,ORDER[1]],AXIS["y",north,ORDER[2]],'
+        'LENGTHUNIT["metre",1]]'
+    )
+
+    with pytest.raises(ValueError, match="EPSG"):
+        RasteretDataset(collection=collection, bands=["B04"], crs=non_epsg)
+
+
+def test_getitem_and_dtype(collection):
+    ds = RasteretDataset(collection=collection, bands=["B04", "B03", "B02"])
+    sample = ds[ds.bounds]
+
+    assert sample["image"].shape == (3, 16, 16)
+    assert ds.dtype == torch.float32
+    ds.is_image = False
+    assert ds.dtype == torch.long
+
+
+def test_res_setter(collection):
+    ds = RasteretDataset(collection=collection, bands=["B04"])
+    ds.res = 20.0
+
+    assert ds.res == (20.0, 20.0)
+
+
+def test_close(collection):
+    ds = RasteretDataset(collection=collection, bands=["B04"])
+    ds.close()
+
+    assert ds._delegate.closed is True
+
+
+def test_crs_setter_rejected(collection):
+    ds = RasteretDataset(collection=collection, bands=["B04"])
+
+    with pytest.raises(AttributeError, match="fixed after construction"):
+        ds.crs = CRS.from_epsg(4326)


### PR DESCRIPTION
## Summary
- add `terratorch.datasets.RasteretDataset` as a Rasteret collection-backed TorchGeo `RasterDataset`
- add `terratorch.datamodules.RasteretDataModule` with stage-specific collection support (`collection` / `collection_name` and per-split overrides)
- expose new classes in package exports and documentation pages
- add optional dependency extra `rasteret>=0.3.7`
- add targeted unit tests for dataset and datamodule behavior

## Validation
- `uvx ruff check terratorch/datasets/rasteret.py terratorch/datamodules/rasteret.py tests/test_rasteret_dataset.py tests/datamodules/test_rasteret.py`
- `uv run --no-sync python -m pytest tests/test_rasteret_dataset.py tests/datamodules/test_rasteret.py -q`

## Notes
- this is intentionally collection-first to align with Rasteret APIs and to keep TorchGeo downstream usage unchanged (samplers/transforms/dataloaders)