### PR TITLE
Fix reshaping temporal means and stds in Normalize function

### DIFF
--- a/terratorch/datamodules/utils.py
+++ b/terratorch/datamodules/utils.py
@@ -225,8 +225,9 @@ class Normalize(Callable):
             if len(self.means.shape) == 2:
                 # Means shape: (C, T) - use full temporal statistics
                 # Reshape to (1, C, T, 1, 1) for broadcasting
-                means = means_tensor.view(1, -1, 1, 1, 1)
-                stds = stds_tensor.view(1, -1, 1, 1, 1)
+                c, t = self.means.shape
+                means = means_tensor.view(1, c, t, 1, 1)
+                stds = stds_tensor.view(1, c, t, 1, 1)
             else:
                 # Means shape: (C,) - replicate across temporal dimension
                 # Reshape to (1, C, 1, 1, 1) for broadcasting


### PR DESCRIPTION
Resolves error message when using temporal mean and stds with `terratorch.datamodules.utils.Normalize`. Explicitly reshapes with the T and C dimensions pulled from the means tensor rather than inferring. Fixes #1171 