### PR TITLE
update docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,49 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material mike mkdocstrings[python] mkdocs-git-revision-date-localized-plugin timm
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs to gh-pages
+        run: |
+          mike deploy --update-aliases latest
+          mike set-default latest
+          git push origin gh-pages

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -71,8 +71,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          mike deploy --push --update-aliases $VERSION stable
-          mike set-default --push stable
+          mike deploy --update-aliases "$VERSION" stable
+          mike set-default stable
+          git push origin gh-pages
 
       - name: Check artifacts
         run: ls -l dist


### PR DESCRIPTION
Updates docs deploy workflow:
- Deploys docs to gh-pages when files in `docs/`,` mkdocs.yml` or docs workflow change on main under latest
- Deploys on releases under stable as before

Also updates both workflows to one gh-pages push instead of of using mike --push twice