### PR TITLE
setuptools: adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools" ]
+requires = [ "setuptools>=77" ]
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools.packages.find]
@@ -9,7 +9,8 @@ include = ["terratorch*"]
 name = "terratorch"
 version = "v1.2.7"
 description = "TerraTorch - The geospatial foundation model fine-tuning toolkit"
-license = { "text" = "Apache License, Version 2.0" }
+license = "Apache-2.0 AND MIT"
+license-files = ["LICENSE", "MIT_FILES.txt"]
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["fine-tuning", "geospatial foundation models", "artificial intelligence"]
@@ -48,7 +49,7 @@ dependencies = [
   "torchvision",
   "rioxarray",
   "albumentations",
-  "albucore", 
+  "albucore",
   "rasterio",
   "torchmetrics",
   "geopandas",


### PR DESCRIPTION
The previous license syntax is deprecated and will be removed from future versions of setuptools, use the recommended [PEP 639](https://peps.python.org/pep-0639/) syntax instead.

Since TerraTorch contains files under an Apache-2.0 license and an MIT license, it should be dual-licensed. It's only a few dataset-specific files, so I think these would be a good target for upstreaming to TorchGeo so that TerraTorch can go back to a single license. Similarly, if we encounter any new FMs we want under an Apache-2.0 license, we will try to push them to TerraTorch instead of TorchGeo.