### PR TITLE
Replace private imports of TorchGeo models

### DIFF
--- a/terratorch/models/backbones/torchgeo_resnet.py
+++ b/terratorch/models/backbones/torchgeo_resnet.py
@@ -8,8 +8,7 @@ from typing import List
 import huggingface_hub
 import torch
 from torch import nn
-from torchgeo.models import resnet
-from torchgeo.models.resnet import ResNet18_Weights, ResNet50_Weights, ResNet152_Weights, resnet18, resnet50, resnet152
+from torchgeo.models import ResNet18_Weights, ResNet50_Weights, ResNet152_Weights, resnet18, resnet50, resnet152
 from torchvision.models._api import Weights, WeightsEnum
 
 from terratorch.datasets.utils import OpticalBands, SARBands

--- a/terratorch/models/backbones/torchgeo_swin_satlas.py
+++ b/terratorch/models/backbones/torchgeo_swin_satlas.py
@@ -8,8 +8,7 @@ from typing import List
 import huggingface_hub
 import torch
 from torch import nn
-from torchgeo.models import swin
-from torchgeo.models.swin import Swin_V2_B_Weights, Swin_V2_T_Weights
+from torchgeo.models import Swin_V2_B_Weights, Swin_V2_T_Weights
 from torchvision.models import swin_v2_b, swin_v2_t
 from torchvision.models._api import Weights, WeightsEnum
 

--- a/terratorch/models/backbones/torchgeo_vit.py
+++ b/terratorch/models/backbones/torchgeo_vit.py
@@ -8,7 +8,7 @@ from typing import List
 import huggingface_hub
 import torch
 from torch import nn
-from torchgeo.models.vit import ViTSmall16_Weights, vit_small_patch16_224
+from torchgeo.models import ViTSmall16_Weights, vit_small_patch16_224
 from torchvision.models._api import Weights, WeightsEnum
 
 from terratorch.models.backbones.select_patch_embed_weights import select_patch_embed_weights

--- a/tests/test_torchgeo_resnet.py
+++ b/tests/test_torchgeo_resnet.py
@@ -59,7 +59,7 @@ from terratorch.models.backbones.torchgeo_resnet import (
     satlas_resnet152_sentinel2_si_ms_satlas,
     satlas_resnet152_sentinel2_si_rgb_satlas,
 )
-from torchgeo.models.resnet import resnet18, resnet50, resnet152
+from torchgeo.models import resnet18, resnet50, resnet152
 
 
 class TestResNetEncoderWrapper:
@@ -70,7 +70,7 @@ class TestResNetEncoderWrapper:
         model = resnet18(in_chans=3)
         meta = {"layers": (2, 2, 2, 2)}
         wrapper = ResNetEncoderWrapper(model, meta, weights=None, out_indices=None)
-        
+
         assert wrapper.out_indices == [-1]
         assert len(wrapper.out_channels) > 0
         gc.collect()
@@ -81,7 +81,7 @@ class TestResNetEncoderWrapper:
         meta = {"layers": (2, 2, 2, 2)}
         out_indices = [0, 1, 2]
         wrapper = ResNetEncoderWrapper(model, meta, weights=None, out_indices=out_indices)
-        
+
         assert wrapper.out_indices == out_indices
         assert len(wrapper.out_channels) == len(out_indices)
         gc.collect()
@@ -91,10 +91,10 @@ class TestResNetEncoderWrapper:
         model = resnet18(in_chans=3)
         meta = {"layers": (2, 2, 2, 2)}
         wrapper = ResNetEncoderWrapper(model, meta, weights=None, out_indices=[-1])
-        
+
         x = torch.randn(1, 3, 224, 224)
         outputs = wrapper(x)
-        
+
         assert isinstance(outputs, list)
         assert len(outputs) == 1
         assert isinstance(outputs[0], torch.Tensor)
@@ -106,10 +106,10 @@ class TestResNetEncoderWrapper:
         meta = {"layers": (2, 2, 2, 2)}
         out_indices = [0, 1, 2, 3]
         wrapper = ResNetEncoderWrapper(model, meta, weights=None, out_indices=out_indices)
-        
+
         x = torch.randn(1, 3, 224, 224)
         outputs = wrapper(x)
-        
+
         assert isinstance(outputs, list)
         assert len(outputs) == len(out_indices)
         for output in outputs:
@@ -121,7 +121,7 @@ class TestResNetEncoderWrapper:
         model = resnet50(in_chans=6)
         meta = {"layers": (3, 4, 6, 3)}
         wrapper = ResNetEncoderWrapper(model, meta, weights=None, out_indices=[0, 2])
-        
+
         assert "original_out_channels" in wrapper.resnet_meta
         assert len(wrapper.resnet_meta["original_out_channels"]) > 0
         gc.collect()
@@ -193,10 +193,10 @@ class TestResNet18Variants:
         """Test ResNet18 variants without pretrained weights."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = model_func(model_bands, pretrained=False)
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         assert len(model.out_channels) > 0
-        
+
         # Test forward pass
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
@@ -208,7 +208,7 @@ class TestResNet18Variants:
         """Test ResNet18 with custom number of input channels."""
         model_bands = ["RED", "GREEN", "BLUE", "NIR_NARROW", "SWIR_1", "SWIR_2"]
         model = ssl4eos12_resnet18_sentinel2_all_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 6, 224, 224)
         outputs = model(x)
         assert isinstance(outputs, list)
@@ -221,7 +221,7 @@ class TestResNet18Variants:
         model = ssl4eol_resnet18_landsat_tm_toa_moco(
             model_bands, pretrained=False, out_indices=out_indices
         )
-        
+
         assert model.out_indices == out_indices
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
@@ -255,10 +255,10 @@ class TestResNet50Variants:
         """Test ResNet50 variants without pretrained weights."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = model_func(model_bands, pretrained=False)
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         assert len(model.out_channels) > 0
-        
+
         # Test forward pass
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
@@ -274,7 +274,7 @@ class TestResNet50Variants:
         """Test ResNet50 Sentinel-1 variants (VV, VH bands)."""
         model_bands = ["VV", "VH"]
         model = model_func(model_bands, pretrained=False)
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         x = torch.randn(1, 2, 224, 224)
         outputs = model(x)
@@ -288,10 +288,10 @@ class TestResNet50Variants:
     ])
     def test_resnet50_sentinel2_all_bands_variants(self, model_func, name):
         """Test ResNet50 Sentinel-2 variants with all bands."""
-        model_bands = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", 
+        model_bands = ["B01", "B02", "B03", "B04", "B05", "B06", "B07",
                       "B08", "B8A", "B09", "B10", "B11", "B12"]
         model = model_func(model_bands, pretrained=False)
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         x = torch.randn(1, 13, 224, 224)
         outputs = model(x)
@@ -302,11 +302,11 @@ class TestResNet50Variants:
         """Test ResNet50 with custom kwargs."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = fmow_resnet50_fmow_rgb_gassl(
-            model_bands, 
+            model_bands,
             pretrained=False,
             in_chans=3
         )
-        
+
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
         assert isinstance(outputs, list)
@@ -326,10 +326,10 @@ class TestResNet152Variants:
         """Test ResNet152 variants without pretrained weights."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = model_func(model_bands, pretrained=False)
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         assert len(model.out_channels) > 0
-        
+
         # Test forward pass
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
@@ -341,7 +341,7 @@ class TestResNet152Variants:
         """Test ResNet152 with multispectral bands."""
         model_bands = ["RED", "GREEN", "BLUE", "NIR_NARROW", "SWIR_1", "SWIR_2"]
         model = satlas_resnet152_sentinel2_si_ms_satlas(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 6, 224, 224)
         outputs = model(x)
         assert isinstance(outputs, list)
@@ -354,9 +354,9 @@ class TestLoadResNetWeights:
     def test_load_weights_from_checkpoint_file(self):
         """Test loading weights from a checkpoint file."""
         from unittest.mock import Mock
-        
+
         model = resnet18(in_chans=3)
-        
+
         # Create a temporary checkpoint
         with tempfile.NamedTemporaryFile(suffix='.pth', delete=False) as tmp:
             # Create a state dict with matching keys
@@ -365,7 +365,7 @@ class TestLoadResNetWeights:
             checkpoint = {k: v for k, v in state_dict.items() if not k.startswith('fc')}
             torch.save(checkpoint, tmp.name)
             tmp_path = tmp.name
-        
+
         try:
             model_bands = ["RED", "GREEN", "BLUE"]
             # Note: load_resnet_weights has a bug - it accesses weights.meta even when
@@ -384,9 +384,9 @@ class TestLoadResNetWeights:
     def test_load_weights_removes_fc_layers(self):
         """Test that fc layers are removed from checkpoint."""
         from unittest.mock import Mock
-        
+
         model = resnet18(in_chans=3)
-        
+
         # Create checkpoint with mismatched fc layers
         with tempfile.NamedTemporaryFile(suffix='.pth', delete=False) as tmp:
             state_dict = model.state_dict()
@@ -396,7 +396,7 @@ class TestLoadResNetWeights:
             checkpoint['fc.bias'] = torch.randn(10)
             torch.save(checkpoint, tmp.name)
             tmp_path = tmp.name
-        
+
         try:
             model_bands = ["RED", "GREEN", "BLUE"]
             # Use mock weights with compatible bands (zero-padded)
@@ -414,7 +414,7 @@ class TestLoadResNetWeights:
         """Test that load_resnet_weights fails when both ckpt_data and weights are None."""
         model = resnet18(in_chans=3)
         model_bands = ["RED", "GREEN", "BLUE"]
-        
+
         # This should fail because the function accesses weights.meta on line 796
         with pytest.raises(AttributeError):
             load_resnet_weights(
@@ -425,24 +425,24 @@ class TestLoadResNetWeights:
     def test_load_weights_with_custom_weight_proj(self):
         """Test loading weights with custom weight projection key."""
         from unittest.mock import Mock
-        
+
         model = resnet18(in_chans=3)
-        
+
         with tempfile.NamedTemporaryFile(suffix='.pth', delete=False) as tmp:
             state_dict = model.state_dict()
             checkpoint = {k: v for k, v in state_dict.items() if not k.startswith('fc')}
             torch.save(checkpoint, tmp.name)
             tmp_path = tmp.name
-        
+
         try:
             model_bands = ["RED", "GREEN", "BLUE"]
             # Use mock weights with compatible bands
             mock_weights = Mock()
             mock_weights.meta = {"bands": ["SENTINEL2.B02", "SENTINEL2.B03", "SENTINEL2.B04"]}
             loaded_model = load_resnet_weights(
-                model, 
-                model_bands, 
-                tmp_path, 
+                model,
+                model_bands,
+                tmp_path,
                 weights=mock_weights,
                 custom_weight_proj="conv1.weight"
             )
@@ -461,7 +461,7 @@ class TestPretrainedWeightsIntegration:
         model = ssl4eos12_resnet18_sentinel2_rgb_moco(
             model_bands, pretrained=False
         )
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         gc.collect()
 
@@ -471,7 +471,7 @@ class TestPretrainedWeightsIntegration:
         model = seco_resnet50_sentinel2_rgb_seco(
             model_bands, pretrained=False
         )
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         gc.collect()
 
@@ -481,7 +481,7 @@ class TestPretrainedWeightsIntegration:
         model = satlas_resnet152_sentinel2_mi_rgb(
             model_bands, pretrained=False
         )
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         gc.collect()
 
@@ -493,10 +493,10 @@ class TestOutputShapes:
         """Test ResNet18 output shapes with default out_indices."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = ssl4eol_resnet18_landsat_tm_toa_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(2, 3, 224, 224)
         outputs = model(x)
-        
+
         assert len(outputs) == 1
         assert outputs[0].shape[0] == 2  # batch size
         gc.collect()
@@ -508,10 +508,10 @@ class TestOutputShapes:
         model = ssl4eos12_resnet50_sentinel2_rgb_moco(
             model_bands, pretrained=False, out_indices=out_indices
         )
-        
+
         x = torch.randn(2, 3, 224, 224)
         outputs = model(x)
-        
+
         assert len(outputs) == len(out_indices)
         for output in outputs:
             assert output.shape[0] == 2  # batch size
@@ -521,10 +521,10 @@ class TestOutputShapes:
         """Test ResNet152 output shapes."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = satlas_resnet152_sentinel2_si_rgb_satlas(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
-        
+
         assert isinstance(outputs, list)
         assert len(outputs) >= 1
         gc.collect()
@@ -538,10 +538,10 @@ class TestDifferentInputSizes:
         """Test ResNet18 with different input sizes."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = ssl4eol_resnet18_landsat_tm_toa_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 3, size, size)
         outputs = model(x)
-        
+
         assert isinstance(outputs, list)
         assert len(outputs) > 0
         gc.collect()
@@ -551,10 +551,10 @@ class TestDifferentInputSizes:
         """Test ResNet50 with different input sizes."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = fmow_resnet50_fmow_rgb_gassl(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 3, size, size)
         outputs = model(x)
-        
+
         assert isinstance(outputs, list)
         assert len(outputs) > 0
         gc.collect()
@@ -568,10 +568,10 @@ class TestBatchProcessing:
         """Test ResNet18 with different batch sizes."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = ssl4eos12_resnet18_sentinel2_rgb_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(batch_size, 3, 224, 224)
         outputs = model(x)
-        
+
         assert outputs[0].shape[0] == batch_size
         gc.collect()
 
@@ -580,10 +580,10 @@ class TestBatchProcessing:
         """Test ResNet50 with different batch sizes."""
         model_bands = ["RED", "GREEN", "BLUE"]
         model = ssl4eos12_resnet50_sentinel2_rgb_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(batch_size, 3, 224, 224)
         outputs = model(x)
-        
+
         assert outputs[0].shape[0] == batch_size
         gc.collect()
 
@@ -595,22 +595,22 @@ class TestEdgeCases:
         """Test model with single band input."""
         model_bands = ["RED"]
         model = ssl4eol_resnet18_landsat_tm_toa_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 1, 224, 224)
         outputs = model(x)
-        
+
         assert isinstance(outputs, list)
         gc.collect()
 
     def test_many_bands_input(self):
         """Test model with many bands."""
-        model_bands = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", 
+        model_bands = ["B01", "B02", "B03", "B04", "B05", "B06", "B07",
                       "B08", "B8A", "B09", "B10", "B11", "B12"]
         model = ssl4eos12_resnet50_sentinel2_all_moco(model_bands, pretrained=False)
-        
+
         x = torch.randn(1, 13, 224, 224)
         outputs = model(x)
-        
+
         assert isinstance(outputs, list)
         gc.collect()
 
@@ -620,10 +620,10 @@ class TestEdgeCases:
         model = ssl4eol_resnet18_landsat_tm_toa_moco(
             model_bands, pretrained=False, out_indices=[-1]
         )
-        
+
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
-        
+
         assert len(outputs) == 1
         gc.collect()
 
@@ -633,10 +633,10 @@ class TestEdgeCases:
         model = ssl4eol_resnet50_landsat_tm_toa_moco(
             model_bands, pretrained=False, out_indices=[0, 1, -1]
         )
-        
+
         x = torch.randn(1, 3, 224, 224)
         outputs = model(x)
-        
+
         # Should return outputs for indices 0, 1, and the last one
         assert len(outputs) == 3
         gc.collect()
@@ -670,17 +670,17 @@ class TestLookupTable:
     def test_lookup_table_completeness(self):
         """Test that lookup table contains expected band mappings."""
         from terratorch.models.backbones.torchgeo_resnet import look_up_table
-        
+
         # Check Sentinel-2 bands
         assert look_up_table["B01"] == "COASTAL_AEROSOL"
         assert look_up_table["B02"] == "BLUE"
         assert look_up_table["B08"] == "NIR_BROAD"
         assert look_up_table["B8A"] == "NIR_NARROW"
-        
+
         # Check Sentinel-1 bands
         assert look_up_table["VV"] == "VV"
         assert look_up_table["VH"] == "VH"
-        
+
         # Check RGB bands
         assert look_up_table["R"] == "RED"
         assert look_up_table["G"] == "GREEN"
@@ -694,7 +694,7 @@ class TestRegistryIntegration:
     def test_resnet18_registered(self):
         """Test that ResNet18 variants are registered."""
         from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
-        
+
         # Test a few variants
         assert "ssl4eol_resnet18_landsat_tm_toa_moco" in TERRATORCH_BACKBONE_REGISTRY
         assert "ssl4eos12_resnet18_sentinel2_all_moco" in TERRATORCH_BACKBONE_REGISTRY
@@ -703,7 +703,7 @@ class TestRegistryIntegration:
     def test_resnet50_registered(self):
         """Test that ResNet50 variants are registered."""
         from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
-        
+
         assert "fmow_resnet50_fmow_rgb_gassl" in TERRATORCH_BACKBONE_REGISTRY
         assert "ssl4eos12_resnet50_sentinel2_all_moco" in TERRATORCH_BACKBONE_REGISTRY
         gc.collect()
@@ -711,7 +711,7 @@ class TestRegistryIntegration:
     def test_resnet152_registered(self):
         """Test that ResNet152 variants are registered."""
         from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
-        
+
         assert "satlas_resnet152_sentinel2_mi_ms" in TERRATORCH_BACKBONE_REGISTRY
         assert "satlas_resnet152_sentinel2_si_rgb_satlas" in TERRATORCH_BACKBONE_REGISTRY
         gc.collect()
@@ -719,13 +719,13 @@ class TestRegistryIntegration:
     def test_build_from_registry(self):
         """Test building model from registry."""
         from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
-        
+
         model = TERRATORCH_BACKBONE_REGISTRY.build(
             "ssl4eos12_resnet18_sentinel2_rgb_moco",
             model_bands=["RED", "GREEN", "BLUE"],
             pretrained=False
         )
-        
+
         assert isinstance(model, ResNetEncoderWrapper)
         gc.collect()
 
@@ -736,7 +736,7 @@ class TestPretrainedModels:
     def test_resnet18_with_pretrained_true_skips_download(self):
         """Test that pretrained=True calls load_resnet_weights (but skip actual download)."""
         model_bands = ["RED", "GREEN", "BLUE"]
-        
+
         # This should try to download weights but we'll catch the error
         # The goal is to cover the pretrained=True branch in model factories
         with pytest.raises(Exception):
@@ -749,7 +749,7 @@ class TestPretrainedModels:
     def test_resnet50_with_pretrained_true_skips_download(self):
         """Test that pretrained=True calls load_resnet_weights for ResNet50."""
         model_bands = ["RED", "GREEN", "BLUE"]
-        
+
         with pytest.raises(Exception):
             model = ssl4eol_resnet50_landsat_tm_toa_moco(
                 model_bands, pretrained=True
@@ -759,7 +759,7 @@ class TestPretrainedModels:
     def test_resnet152_with_pretrained_true_skips_download(self):
         """Test that pretrained=True calls load_resnet_weights for ResNet152."""
         model_bands = ["B02", "B03", "B04"]
-        
+
         # This may actually succeed in downloading if internet is available
         # The goal is to cover the pretrained=True branch
         try:
@@ -783,20 +783,20 @@ class TestWeightsEnumLoading:
         from torchgeo.models import ResNet18_Weights
         from torchgeo.models import resnet18
         from unittest.mock import Mock, patch
-        
+
         model = resnet18(in_chans=3)
         model_bands = ["B02", "B03", "B04"]
-        
+
         # Mock the weights object and its get_state_dict method
         mock_weights = Mock()
         mock_weights.meta = {"bands": ["SENTINEL2.B02", "SENTINEL2.B03", "SENTINEL2.B04"]}
-        
+
         # Create a fake state dict
         state_dict = model.state_dict()
         fake_checkpoint = {k: v for k, v in state_dict.items()}
-        
+
         mock_weights.get_state_dict.return_value = fake_checkpoint
-        
+
         # This should go through the weights.get_state_dict() path (lines 820-825)
         loaded_model = load_resnet_weights(
             model,
@@ -804,7 +804,7 @@ class TestWeightsEnumLoading:
             ckpt_data=None,  # No checkpoint file
             weights=mock_weights  # Use weights enum
         )
-        
+
         assert isinstance(loaded_model, nn.Module)
         assert mock_weights.get_state_dict.called
         gc.collect()
@@ -814,25 +814,25 @@ class TestWeightsEnumLoading:
         from torchgeo.models import resnet18
         from unittest.mock import Mock, patch
         import huggingface_hub
-        
+
         model = resnet18(in_chans=3)
         model_bands = ["B02", "B03", "B04"]
-        
+
         # Mock HF download
         with tempfile.NamedTemporaryFile(suffix='.pth', delete=False) as tmp:
             state_dict = model.state_dict()
             checkpoint = {k: v for k, v in state_dict.items() if not k.startswith('fc')}
             torch.save(checkpoint, tmp.name)
             tmp_path = tmp.name
-        
+
         try:
             def mock_hf_download(repo_id, filename):
                 return tmp_path
-            
+
             with patch.object(huggingface_hub, 'hf_hub_download', side_effect=mock_hf_download):
                 mock_weights = Mock()
                 mock_weights.meta = {"bands": ["SENTINEL2.B02", "SENTINEL2.B03", "SENTINEL2.B04"]}
-                
+
                 # This should go through the HF download path (lines 799-801)
                 hf_url = "https://hf.co/test/model/resolve/main/checkpoint.pth"
                 loaded_model = load_resnet_weights(
@@ -841,11 +841,11 @@ class TestWeightsEnumLoading:
                     ckpt_data=hf_url,
                     weights=mock_weights
                 )
-                
+
                 assert isinstance(loaded_model, nn.Module)
         finally:
             os.unlink(tmp_path)
-        
+
         gc.collect()
 
 
@@ -857,21 +857,21 @@ class TestSelectPatchEmbedWeights:
         from torchgeo.models import resnet18
         from unittest.mock import Mock, patch
         from terratorch.models.backbones import select_patch_embed_weights
-        
+
         model = resnet18(in_chans=3)
         model_bands = ["B02", "B03", "B04"]
-        
+
         with tempfile.NamedTemporaryFile(suffix='.pth', delete=False) as tmp:
             state_dict = model.state_dict()
             checkpoint = {k: v for k, v in state_dict.items()}
             torch.save(checkpoint, tmp.name)
             tmp_path = tmp.name
-        
+
         try:
             mock_weights = Mock()
             mock_weights.meta = {"bands": ["SENTINEL2.B02", "SENTINEL2.B03", "SENTINEL2.B04"]}
-            
-            with patch('terratorch.models.backbones.torchgeo_resnet.select_patch_embed_weights', 
+
+            with patch('terratorch.models.backbones.torchgeo_resnet.select_patch_embed_weights',
                       side_effect=select_patch_embed_weights.select_patch_embed_weights) as mock_select:
                 loaded_model = load_resnet_weights(
                     model,
@@ -879,13 +879,13 @@ class TestSelectPatchEmbedWeights:
                     ckpt_data=tmp_path,
                     weights=mock_weights
                 )
-                
+
                 # Verify select_patch_embed_weights was called
                 assert mock_select.called
                 assert isinstance(loaded_model, nn.Module)
         finally:
             os.unlink(tmp_path)
-        
+
         gc.collect()
 
 
@@ -908,7 +908,7 @@ class TestMultipleModelVariants:
         """Test various model factory functions to increase line coverage."""
         model = model_factory(model_bands, pretrained=False)
         assert isinstance(model, ResNetEncoderWrapper)
-        
+
         # Test forward pass
         x = torch.randn(1, len(model_bands), 224, 224)
         outputs = model(x)
@@ -970,7 +970,7 @@ class TestMultipleModelVariants:
     ])
     def test_models_with_pretrained_flag(self, model_factory, model_bands):
         """Test model variants with pretrained=True to cover weight loading branches.
-        
+
         This test covers the 'if pretrained:' branches in each model factory function.
         It may succeed (if weights download) or fail (if no internet), both are acceptable.
         """


### PR DESCRIPTION
Things like `torchgeo.models.resnet` are not documented and considered an implementation detail. Only the top-level `torchgeo.models` API is public.

Fixes #1031