### PR TITLE
Fix: Resolve KeyError and NameError in TorchGeo backbones weight loading

### DIFF
--- a/terratorch/models/backbones/torchgeo_resnet.py
+++ b/terratorch/models/backbones/torchgeo_resnet.py
@@ -74,6 +74,18 @@ look_up_table = {
     "B10": "CIRRUS",
     "B11": "SWIR_1",
     "B12": "SWIR_2",
+
+    "B1": "COASTAL_AEROSOL",
+    "B2": "BLUE",
+    "B3": "GREEN",
+    "B4": "RED",
+    "B5": "RED_EDGE_1",
+    "B6": "RED_EDGE_2",
+    "B7": "RED_EDGE_3",
+    "B8": "NIR_BROAD",
+    "B8a": "NIR_NARROW",
+    "B9": "WATER_VAPOR",
+
     "VV": "VV",
     "VH": "VH",
     "R": "RED",

--- a/terratorch/models/backbones/torchgeo_swin_satlas.py
+++ b/terratorch/models/backbones/torchgeo_swin_satlas.py
@@ -78,6 +78,18 @@ look_up_table = {
     "B10": "CIRRUS",
     "B11": "SWIR_1",
     "B12": "SWIR_2",
+
+    "B1": "COASTAL_AEROSOL",
+    "B2": "BLUE",
+    "B3": "GREEN",
+    "B4": "RED",
+    "B5": "RED_EDGE_1",
+    "B6": "RED_EDGE_2",
+    "B7": "RED_EDGE_3",
+    "B8": "NIR_BROAD",
+    "B8a": "NIR_NARROW",
+    "B9": "WATER_VAPOR",
+
     "VV": "VV",
     "VH": "VH",
     "R": "RED",

--- a/terratorch/models/backbones/torchgeo_vit.py
+++ b/terratorch/models/backbones/torchgeo_vit.py
@@ -56,6 +56,18 @@ look_up_table = {
     "B10": "CIRRUS",
     "B11": "SWIR_1",
     "B12": "SWIR_2",
+
+    "B1": "COASTAL_AEROSOL",
+    "B2": "BLUE",
+    "B3": "GREEN",
+    "B4": "RED",
+    "B5": "RED_EDGE_1",
+    "B6": "RED_EDGE_2",
+    "B7": "RED_EDGE_3",
+    "B8": "NIR_BROAD",
+    "B8a": "NIR_NARROW",
+    "B9": "WATER_VAPOR",
+
     "VV": "VV",
     "VH": "VH",
     "R": "RED",
@@ -400,7 +412,13 @@ def load_vit_weights(
         logging.info(msg)
     elif weights is not None:
         checkpoint_model = weights.get_state_dict(progress=True)
-        checkpoint_model = remove_keys(checkpoint_model, model.state_dict())
+        state_dict = model.state_dict()
+        
+        for k in ["head.weight", "head.bias"]:
+            if k in checkpoint_model and checkpoint_model[k].shape != state_dict[k].shape:
+                logging.info(f"Removing key {k} from pretrained checkpoint")
+                del checkpoint_model[k]
+        
         checkpoint_model = select_patch_embed_weights(
             checkpoint_model, model, pretrained_bands, model_bands, custom_weight_proj
         )

--- a/tests/test_torchgeo_resnet.py
+++ b/tests/test_torchgeo_resnet.py
@@ -734,26 +734,23 @@ class TestPretrainedModels:
     """Test models with pretrained=True flag."""
 
     def test_resnet18_with_pretrained_true_skips_download(self):
-        """Test that pretrained=True calls load_resnet_weights (but skip actual download)."""
+        """Test that pretrained=True calls load_resnet_weights."""
         model_bands = ["RED", "GREEN", "BLUE"]
 
-        # This should try to download weights but we'll catch the error
-        # The goal is to cover the pretrained=True branch in model factories
-        with pytest.raises(Exception):
-            # Will fail when trying to download, but covers the pretrained branch
-            model = ssl4eol_resnet18_landsat_tm_toa_moco(
-                model_bands, pretrained=True
-            )
+        # Thanks to the recent fix in torchgeo backbones, this now correctly 
+        # executes the pretrained branch without raising unintended exceptions.
+        model = ssl4eol_resnet18_landsat_tm_toa_moco(
+            model_bands, pretrained=True
+        )
         gc.collect()
 
     def test_resnet50_with_pretrained_true_skips_download(self):
         """Test that pretrained=True calls load_resnet_weights for ResNet50."""
         model_bands = ["RED", "GREEN", "BLUE"]
 
-        with pytest.raises(Exception):
-            model = ssl4eol_resnet50_landsat_tm_toa_moco(
-                model_bands, pretrained=True
-            )
+        model = ssl4eol_resnet50_landsat_tm_toa_moco(
+            model_bands, pretrained=True
+        )
         gc.collect()
 
     def test_resnet152_with_pretrained_true_skips_download(self):


### PR DESCRIPTION
## Description
This PR fixes two bugs that prevent the initialization of several TorchGeo-based backbones when using `pretrained=True`.

### 1. Missing TorchGeo Bands (`KeyError`)
**Files modified:** `terratorch/models/backbones/torchgeo_resnet.py`, `terratorch/models/backbones/torchgeo_vit.py` and `terratorch/models/backbones/torchgeo_swin_satlas.py`
- **Issue:** When loading weights, TorchGeo models often define their Sentinel-2 bands using formats like `"B4"`, `"B3"`, or `"B8a"`. These keys were missing from the `look_up_table`, causing a `KeyError` to be raised during `get_pretrained_bands()`. 
- **Fix:** Added the legacy TorchGeo band formats (`"B1"` to `"B9"`, specifically including the lowercase `"B8a"` which was causing silent failures) to the `look_up_table`. I proactively applied this fix to the Swin Satlas backbone as well to prevent identical crashes.

### 2. Undefined Function (`NameError`)
**File modified:** `terratorch/models/backbones/torchgeo_vit.py`
- **Issue:** In the `load_vit_weights` function, the `elif weights is not None` block calls a `remove_keys()` function. This function is not defined anywhere in the file or imported, resulting in a `NameError: name 'remove_keys' is not defined`.
- **Fix:** Replaced the undefined `remove_keys` call with the explicit dictionary key deletion logic (`for k in ["head.weight", "head.bias"]: del ...`) that is already correctly implemented a few lines above in the same file.

## Testing
Tested locally. Models such as `seco_resnet18_sentinel2_rgb_seco` and `ssl4eos12_vit_small_patch16_224_sentinel2_all_dino` now successfully translate band names, process the checkpoints, and load their pretrained weights without crashing.