### PR TITLE
Added temporary fix to support vLLM >0.21.0 and <=0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ dependencies = [
 terratorch_segmentation = "terratorch.vllm.plugins.segmentation:register_segmentation_plugin"
 terratorch_tm_segmentation = "terratorch.vllm.plugins.segmentation:register_terramind_segmentation_plugin"
 
+[project.entry-points."vllm.general_plugins"]
+terratorch_fix = "terratorch.vllm.plugins.general:register_terratorch_fix"
+
 [project.optional-dependencies]
 logging = [
   "wandb>=0.18.0",

--- a/terratorch/vllm/plugins/general/__init__.py
+++ b/terratorch/vllm/plugins/general/__init__.py
@@ -1,0 +1,18 @@
+from vllm.model_executor.models.registry import ModelRegistry
+from vllm.logger import init_logger
+
+def register_terratorch_fix():
+    logger = init_logger(__name__)
+
+    try:
+        ModelRegistry.register_model(
+            "Terratorch",
+            "terratorch.vllm.plugins.general.terratorch:TerratorchFix",
+        )
+        logger.info(
+            "Successfully registered TerratorchFix model with vLLM, "
+            "this is only required to support vLLM >0.21.0 <=0.24.0 due to a known bug"
+        )
+    except Exception as e:
+        logger.error(f"Failed to register TerratorchFix model: {e}")
+        raise

--- a/terratorch/vllm/plugins/general/terratorch.py
+++ b/terratorch/vllm/plugins/general/terratorch.py
@@ -1,0 +1,9 @@
+from vllm.model_executor.models.terratorch import Terratorch
+
+# This class is only needed for supporting vLLM >0.21.0 and <=0.24.0
+# where models that do not define a language model fail loading.
+# A proper fix in vLLM is under way.
+class TerratorchFix(Terratorch):
+    
+    def get_language_model(self):
+        return self


### PR DESCRIPTION
In vLLM >0.21.0 and <=0.24.0 models that do not register a "language model" fail loading. This pr installs a fix that makes the Terratorch models load and work as expected.

A proper fix is already on the way and will be included in vLLMm > 0.24.0