### PR TITLE
Pr 1203

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ dependencies = [
 terratorch_segmentation = "terratorch.vllm.plugins.segmentation:register_segmentation_plugin"
 terratorch_tm_segmentation = "terratorch.vllm.plugins.segmentation:register_terramind_segmentation_plugin"
 
+[project.entry-points."vllm.general_plugins"]
+terratorch_fix = "terratorch.vllm.plugins.general:register_terratorch_fix"
+
 [project.optional-dependencies]
 logging = [
   "wandb>=0.18.0",

--- a/terratorch/models/detr/terratorch_detr.py
+++ b/terratorch/models/detr/terratorch_detr.py
@@ -468,7 +468,8 @@ class TerraTorchRFDETR(nn.Module):
         """Adapt TerraTorch BackboneWrapper to RF-DETR Joiner-like contract.
 
         Upstream RF-DETR `LWDETR` expects a backbone module that accepts a
-        NestedTensor and returns `(features, pos)` where:
+        NestedTensor and returns either `(features, pos)` (older RF-DETR) or
+        `(features, pos, cross_attn_features)` (newer RF-DETR), where:
         - features: list of NestedTensor objects
         - pos: list of positional encodings in [B, C, H, W]
         """
@@ -479,6 +480,10 @@ class TerraTorchRFDETR(nn.Module):
             self.input_proj = input_proj
             self.position_embedding = position_embedding
             self.num_feature_levels = num_feature_levels
+            # RF-DETR changed backbone unpacking from 2 values to 3 values.
+            # Start in legacy mode and flip automatically if runtime indicates
+            # the newer contract is required.
+            self.return_cross_attn_features = False
 
         def _resized_mask(self, base_mask: Tensor | None, src: Tensor) -> Tensor:
             if base_mask is None:
@@ -519,6 +524,8 @@ class TerraTorchRFDETR(nn.Module):
                     out.append(nested)
                     pos.append(self.position_embedding(nested, align_dim_orders=False).to(src.dtype))
 
+            if self.return_cross_attn_features:
+                return out, pos, None
             return out, pos
 
     def __init__(
@@ -699,7 +706,21 @@ class TerraTorchRFDETR(nn.Module):
         bs, _, img_h, img_w = images.shape
 
         # Run upstream LWDETR model (it builds NestedTensor flow internally).
-        outputs = self.lwdetr(images)
+        # RF-DETR versions in our allowed dependency range use different
+        # backbone return contracts (2 vs 3 unpacked values). We retry once and
+        # flip adapter mode when the unpacking error indicates a mismatch.
+        try:
+            outputs = self.lwdetr(images)
+        except ValueError as ex:
+            msg = str(ex)
+            if "expected 3, got 2" in msg and not self.backbone_adapter.return_cross_attn_features:
+                self.backbone_adapter.return_cross_attn_features = True
+                outputs = self.lwdetr(images)
+            elif "expected 2" in msg and self.backbone_adapter.return_cross_attn_features:
+                self.backbone_adapter.return_cross_attn_features = False
+                outputs = self.lwdetr(images)
+            else:
+                raise
 
         if self.training:
             if targets is None:

--- a/terratorch/vllm/plugins/general/__init__.py
+++ b/terratorch/vllm/plugins/general/__init__.py
@@ -1,0 +1,18 @@
+from vllm.model_executor.models.registry import ModelRegistry
+from vllm.logger import init_logger
+
+def register_terratorch_fix():
+    logger = init_logger(__name__)
+
+    try:
+        ModelRegistry.register_model(
+            "Terratorch",
+            "terratorch.vllm.plugins.general.terratorch:TerratorchFix",
+        )
+        logger.info(
+            "Successfully registered TerratorchFix model with vLLM, "
+            "this is only required to support vLLM >0.21.0 <=0.24.0 due to a known bug"
+        )
+    except Exception as e:
+        logger.error(f"Failed to register TerratorchFix model: {e}")
+        raise

--- a/terratorch/vllm/plugins/general/terratorch.py
+++ b/terratorch/vllm/plugins/general/terratorch.py
@@ -1,0 +1,9 @@
+from vllm.model_executor.models.terratorch import Terratorch
+
+# This class is only needed for supporting vLLM >0.21.0 and <=0.24.0
+# where models that do not define a language model fail loading.
+# A proper fix in vLLM is under way.
+class TerratorchFix(Terratorch):
+    
+    def get_language_model(self):
+        return self


### PR DESCRIPTION
**Problem:**

RF-DETR version got an update.
Some versions expect 2 values from the backbone, newer ones expect 3(Features, Positions, cross-attn-features [new]).
Our code always returned 2, so tests failed with:
expected 3, got 2.

  **Fix:**

I updated terratorch/models/detr/terratorch_detr.py to support both cases[set the cross-attn-features to None and ignore it in the next steps ].
It now retries once and switches to the right format automatically.