### PR TITLE
integrationtests: make /dccstor data paths overridable via TERRATORCH_DATA_ROOT

### DIFF
--- a/integrationtests/test_base_set.py
+++ b/integrationtests/test_base_set.py
@@ -24,11 +24,16 @@ from terratorch.registry import BACKBONE_REGISTRY
 from terratorch.tasks import InferenceTask
 
 # Allow overriding default test asset locations via environment variables.
+# DATA_ROOT is the shared storage prefix that all the default paths below live
+# under. Overriding it (e.g. when the /dccstor mount is unavailable) relocates the
+# input datasets referenced by the fit configs; it defaults to "/dccstor" so the
+# behaviour is unchanged when unset.
+DATA_ROOT = os.getenv("TERRATORCH_DATA_ROOT", "/dccstor")
 TEST_MODELS_ROOT = os.getenv(
     "TERRATORCH_TEST_MODELS_ROOT",
-    "/dccstor/terratorch/shared/integrationtests/testing_models",
+    f"{DATA_ROOT}/terratorch/shared/integrationtests/testing_models",
 )
-TMP_ROOT = os.getenv("TERRATORCH_TMP_ROOT", "/dccstor/terratorch/tmp")
+TMP_ROOT = os.getenv("TERRATORCH_TMP_ROOT", f"{DATA_ROOT}/terratorch/tmp")
 TEST_CHECKPOINTS_ROOT = os.getenv("TERRATORCH_TEST_CHECKPOINTS_ROOT", TEST_MODELS_ROOT)
 
 
@@ -89,9 +94,13 @@ def test_models_fit(model_name):
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
 
-    # Replace /dccstor/terratorch/tmp with TMP_ROOT in the config
+    # Relocate hard-coded storage paths in the config to the configured roots.
+    # Replace the output/checkpoint dir first (most specific), then relocate any
+    # remaining /dccstor input-dataset paths onto DATA_ROOT. Both are no-ops with
+    # the default settings, so the shared-cluster behaviour is unchanged.
     config_str = yaml.dump(config)
     config_str = config_str.replace("/dccstor/terratorch/tmp", TMP_ROOT)
+    config_str = config_str.replace("/dccstor", DATA_ROOT)
     config = yaml.safe_load(config_str)
 
     # Write the modified config to a temporary file

--- a/scripts/README_run_lsf_integrationtest.md
+++ b/scripts/README_run_lsf_integrationtest.md
@@ -318,6 +318,34 @@ The following environment variables are set based on command-line options:
 - `TERRATORCH_TMP_ROOT`: Set when `--terratorch-tmp-root` is provided. Specifies
   custom temporary directory location.
 
+#### Relocating test assets off `/dccstor`
+
+The integration tests default to the shared `/dccstor` storage. On clusters where
+that mount is unavailable, override these variables to point at a local mirror of
+the data (all default to their original `/dccstor` locations, so unset behaviour is
+unchanged):
+
+- `TERRATORCH_DATA_ROOT`: Storage prefix that replaces `/dccstor` in the fit
+  configs' input-dataset paths (e.g. `geofm-datasets`, `geofm-finetuning`).
+  Default: `/dccstor`. Set this to the root of a mirror that preserves the
+  `/dccstor/...` sub-paths (e.g. mirror `/dccstor/geofm-datasets/...` to
+  `$TERRATORCH_DATA_ROOT/geofm-datasets/...`).
+- `TERRATORCH_TEST_MODELS_ROOT`: Location of the pre-trained testing models used by
+  the legacy predict tests. Default:
+  `$TERRATORCH_DATA_ROOT/terratorch/shared/integrationtests/testing_models`.
+- `TERRATORCH_TEST_CHECKPOINTS_ROOT`: Location of the legacy checkpoints. Defaults
+  to `TERRATORCH_TEST_MODELS_ROOT`.
+- `TERRATORCH_TMP_ROOT`: Writable directory for fit outputs/checkpoints. Default:
+  `$TERRATORCH_DATA_ROOT/terratorch/tmp`.
+
+Example (mirror rooted at `/proj/.../terratorch/datasets`):
+
+```bash
+export TERRATORCH_DATA_ROOT=/proj/partnership-mat/terratorch/datasets
+export TERRATORCH_TMP_ROOT=/proj/partnership-mat/terratorch/tmp
+pytest integrationtests/test_base_set.py
+```
+
 ### Direct Tox Usage
 
 You can also run tox directly with these environment variables:


### PR DESCRIPTION
## Summary

The integration tests (`integrationtests/test_base_set.py` + its fit configs) hard-code the shared `/dccstor` storage prefix for input datasets. On clusters where `/dccstor` is not mounted, `test_models_fit` fails immediately with `PermissionError: [Errno 13] Permission denied: '/dccstor'`, which cascades to every dependent predict test.

`TERRATORCH_TMP_ROOT` and `TERRATORCH_TEST_MODELS_ROOT` were already overridable, but the **input-dataset roots** in the fit configs (`/dccstor/geofm-datasets/...`, `/dccstor/geofm-finetuning/...`) were not. This PR closes that gap.

## Changes

- Add `TERRATORCH_DATA_ROOT` (default `/dccstor`). `TEST_MODELS_ROOT` and `TMP_ROOT` defaults now derive from it.
- In `test_models_fit`, after the existing `→ TMP_ROOT` substitution, relocate any remaining `/dccstor` paths onto `DATA_ROOT`, so dataset roots follow the same override.
- Document `TERRATORCH_DATA_ROOT` / `TERRATORCH_TEST_MODELS_ROOT` / `TERRATORCH_TEST_CHECKPOINTS_ROOT` / `TERRATORCH_TMP_ROOT` in the LSF runner README, with a mirror example.

## Backward compatibility

Fully backward-compatible: with the env vars unset, every path resolves to its original `/dccstor` location, so behaviour on the shared cluster is unchanged.

## Testing

Verified the substitution resolves all base-set config dataset/output/model roots onto a local mirror (no bare `/dccstor` left) when `TERRATORCH_DATA_ROOT` points at a mirror that preserves the `/dccstor/...` sub-paths. End-to-end run against a full CCC→BlueVela data mirror in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)