### PR TITLE
Bump version to v1.2.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["terratorch*"]
 
 [project]
 name = "terratorch"
-version = "v1.2.8"
+version = "v1.2.9"
 description = "TerraTorch - The geospatial foundation model fine-tuning toolkit"
 license = "Apache-2.0 AND MIT"
 license-files = ["LICENSE", "MIT_FILES.txt"]


### PR DESCRIPTION
## Summary

Bumps the package version `v1.2.8` → `v1.2.9` in `pyproject.toml` in preparation for the v1.2.9 release.

## Release process

After this merges to `main`, tagging `v1.2.9` on `main` triggers `publish-pypi.yml`, which builds & publishes the package to PyPI and deploys the versioned docs (`mike deploy v1.2.9 stable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)