### PR TITLE
Remove geobenchv2 from test and vllm optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["terratorch*"]
 
 [project]
 name = "terratorch"
-version = "v1.2.9"
+version = "v1.2.10"
 description = "TerraTorch - The geospatial foundation model fine-tuning toolkit"
 license = "Apache-2.0 AND MIT"
 license-files = ["LICENSE", "MIT_FILES.txt"]
@@ -108,7 +108,6 @@ test = [
   "numba",
   "hdf5plugin",
   "h5netcdf",
-  "geobenchv2>=0.9",
   "terratorch-surya>=0.1.0",
 #  "PrithviWxC",  # Currently fails of pypi version conflics
 #  "granitewxc",  # Currently fails of pypi version conflics
@@ -152,7 +151,6 @@ geobenchv2 = [
 ]
 
 vllm = [
-  "geobenchv2>=0.9",
   "impactmesh>0.1.0",
   "vllm>=0.19.0",
 ]


### PR DESCRIPTION
## Summary

The `geobench_v2` import in `terratorch/datamodules/__init__.py` is already wrapped in a `try/except ImportError` guard (introduced in [PR #989](https://github.com/IBM/terratorch/pull/989) by Naomi Simumba). This means `geobench_v2` is already an optional runtime dependency.

However, it was still listed as a required entry in both the `test` and `vllm` optional extras in `pyproject.toml`, forcing it to be installed unnecessarily in those environments.

## Changes

- Remove `geobenchv2>=0.9` from the `test` extras — tests work without it; the `geobench_v2` datamodule classes are simply not exposed if the package is absent.
- Remove `geobenchv2>=0.9` from the `vllm` extras — no code under `terratorch/vllm/` imports `geobench_v2`.

The dedicated `[geobenchv2]` optional extras group is unchanged — users who need the integration can still install it via `pip install terratorch[geobenchv2]`.

## Verification

- All `m_*.py` dataset files have zero `geobench` imports (only `torchgeo`, `h5py`, `albumentations`, `numpy`).
- All `m_*.py` datamodule files only import the internal `GeobenchDataModule` class, which has no external `geobench` dependency.
- The only real `geobench_v2` import (`geobench_v2_data_module.py`) is already guarded in `__init__.py`.